### PR TITLE
BUILD-4135 Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @sonarsource/sonarcloud @sonarsource/sonarqube-team
+.github/CODEOWNERS @sonarsource/sonarcloud


### PR DESCRIPTION
it appears only one team can be owner of a repository (RE checks are reporting this repo as not respecting this rule)