### PR TITLE
DS-510 Simplify the LinkBase implementation

### DIFF
--- a/src/common/components/NavLinkBase.tsx
+++ b/src/common/components/NavLinkBase.tsx
@@ -1,0 +1,75 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
+import { forwardRef } from 'react';
+import { useIntl } from 'react-intl';
+import { NavLink as RouterNavLink, NavLinkProps as RouterNavLinkProps } from 'react-router-dom';
+import { isSonarLink } from '~common/helpers/url';
+
+type RouterNavLinkPropsAllowed = 'download' | 'to';
+
+export interface NavLinkBaseProps extends Pick<RouterNavLinkProps, RouterNavLinkPropsAllowed> {
+  children: React.ReactNode;
+  isMatchingFullPath?: boolean;
+  shouldOpenInNewTab?: boolean;
+}
+
+export const NavLinkBase = forwardRef<HTMLAnchorElement, NavLinkBaseProps>((props, ref) => {
+  const {
+    children,
+    isMatchingFullPath = false,
+    shouldOpenInNewTab = false,
+    to,
+    ...restAndRadixProps
+  } = props;
+
+  const intl = useIntl();
+
+  const shouldOpenInNewTabProps = shouldOpenInNewTab
+    ? {
+        rel: `noopener${typeof to === 'string' && isSonarLink(to) ? '' : ' noreferrer nofollow'}`,
+        /* eslint-disable-next-line react/jsx-no-target-blank -- we only allow noopener noreferrer for known external links */
+        target: '_blank',
+      }
+    : {};
+
+  return (
+    <RouterNavLink
+      {...(isMatchingFullPath ? { end: true } : {})}
+      {...shouldOpenInNewTabProps}
+      {...restAndRadixProps}
+      ref={ref}
+      to={to}>
+      {children}
+
+      {shouldOpenInNewTab && (
+        <VisuallyHidden.Root>
+          {intl.formatMessage({
+            id: 'open_in_new_tab',
+            defaultMessage: '(opens in new tab)',
+            description: 'Screen reader-only text to indicate that the link will open in a new tab',
+          })}
+        </VisuallyHidden.Root>
+      )}
+    </RouterNavLink>
+  );
+});
+
+NavLinkBase.displayName = 'NavLinkBase';

--- a/src/components/dropdown-menu/DropdownMenuItemLink.tsx
+++ b/src/components/dropdown-menu/DropdownMenuItemLink.tsx
@@ -20,18 +20,13 @@
 
 import styled from '@emotion/styled';
 import { forwardRef } from 'react';
+import { NavLinkBase, NavLinkBaseProps } from '~common/components/NavLinkBase';
 import { IconLinkExternal } from '../icons/IconLinkExternal';
-import { LinkBase, LinkBaseProps } from '../links/LinkBase';
 import { DropdownMenuItemBase, DropdownMenuItemBaseProps } from './DropdownMenuItemBase';
 
-type Props = Omit<
-  DropdownMenuItemBaseProps,
-  'isCheckable' | 'isChecked' | 'ItemWrapper' | 'itemWrapperProps'
-> &
-  Pick<
-    LinkBaseProps,
-    'download' | 'hasExternalIcon' | 'isMatchingFullPath' | 'shouldOpenInNewTab' | 'to'
-  >;
+type Props = Omit<DropdownMenuItemBaseProps, 'isCheckable' | 'isChecked'> & {
+  hasExternalIcon?: boolean;
+} & Pick<NavLinkBaseProps, 'download' | 'isMatchingFullPath' | 'shouldOpenInNewTab' | 'to'>;
 
 const getComposedSuffix = ({
   shouldOpenInNewTab,
@@ -84,24 +79,18 @@ export const DropdownMenuItemLink = forwardRef<HTMLDivElement, Props>((props, re
   return (
     <StyledDropdownMenuItemBase {...itemProps} ref={ref}>
       {({ getStyledItemContents }) => (
-        <StyledLinkBase
+        <StyledNavLinkBase
           download={download}
-          hasExternalIcon={false}
           isMatchingFullPath={isMatchingFullPath}
-          isNavLink
           shouldOpenInNewTab={shouldOpenInNewTab}
           to={to}>
           {getStyledItemContents({ label: children })}
-        </StyledLinkBase>
+        </StyledNavLinkBase>
       )}
     </StyledDropdownMenuItemBase>
   );
 });
 DropdownMenuItemLink.displayName = 'DropdownMenu.ItemLink';
-
-const StyledLinkBase = styled(LinkBase)`
-  text-decoration: none;
-`;
 
 const StyledDropdownMenuItemBase = styled(DropdownMenuItemBase)`
   /* when the current URL matches 'to', react-router adds an 'active' class to the 'a' tag */
@@ -112,6 +101,10 @@ const StyledDropdownMenuItemBase = styled(DropdownMenuItemBase)`
   &[data-disabled] {
     background-color: var(--echoes-color-background-default);
   }
+`;
+
+const StyledNavLinkBase = styled(NavLinkBase)`
+  text-decoration: none;
 `;
 
 const StyledIconLinkExternal = styled(IconLinkExternal)`

--- a/src/components/dropdown-menu/DropdownMenuItemLinkDownload.tsx
+++ b/src/components/dropdown-menu/DropdownMenuItemLinkDownload.tsx
@@ -19,12 +19,13 @@
  */
 
 import { forwardRef } from 'react';
-import { IconDownload, LinkProps } from '..';
+import { NavLinkBaseProps } from '~common/components/NavLinkBase';
+import { IconDownload } from '..';
 import { DropdownMenuItemBaseProps } from './DropdownMenuItemBase';
 import { DropdownMenuItemLink } from './DropdownMenuItemLink';
 
 type Props = Omit<DropdownMenuItemBaseProps, 'isCheckable' | 'isChecked' | 'prefix' | 'suffix'> &
-  Pick<LinkProps, 'to'> & { download: string };
+  Pick<NavLinkBaseProps, 'to'> & { download: string };
 
 export const DropdownMenuItemLinkDownload = forwardRef<HTMLDivElement, Props>((props, ref) => {
   return (

--- a/src/components/links/Link.tsx
+++ b/src/components/links/Link.tsx
@@ -17,15 +17,8 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-
-import { forwardRef } from 'react';
-import { LinkBaseFixedProps } from './LinkBase';
 import { LinkBaseStyled } from './LinkBaseStyled';
 
-export type LinkProps = Omit<LinkBaseFixedProps, 'hasExternalIcon'>;
-
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
-  <LinkBaseStyled {...{ ...props, ref }} />
-));
+export const Link = LinkBaseStyled;
 
 Link.displayName = 'Link';

--- a/src/components/links/LinkStandalone.tsx
+++ b/src/components/links/LinkStandalone.tsx
@@ -22,18 +22,18 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { forwardRef } from 'react';
 import { LinkHighlight } from '.';
-import { LinkProps } from './Link';
+import { LinkProps } from './LinkBase';
 import { LinkBaseStyled } from './LinkBaseStyled';
 
-type Props = LinkProps & {
+interface Props extends LinkProps {
   iconLeft?: React.ReactNode;
-};
+}
 
 const LinkStandaloneBase = forwardRef<HTMLAnchorElement, Props>((props, ref) => {
   const { children, iconLeft, ...linkProps } = props;
 
   return (
-    <LinkBaseStyled hasExternalIcon={!iconLeft} {...linkProps} ref={ref}>
+    <LinkBaseStyled {...linkProps} ref={ref}>
       {iconLeft}
 
       {children}

--- a/src/components/links/__tests__/Link-test.tsx
+++ b/src/components/links/__tests__/Link-test.tsx
@@ -121,17 +121,6 @@ it('external links are indicated by additional text', async () => {
   await expect(container).toHaveNoA11yViolations();
 });
 
-it('should override target if passed as a prop for external link', () => {
-  const onClick = jest.fn();
-  setupWithMemoryRouter(
-    <Link onClick={onClick} target="_self" to="https://google.com">
-      Test
-    </Link>,
-  );
-
-  expect(screen.getByRole('link')).toHaveAttribute('target', '_self');
-});
-
 it('should correclty support tooltips', async () => {
   const { user } = setupWithMemoryRouter(
     <Tooltip content="my tooltip">

--- a/src/components/links/__tests__/LinkStandalone-test.tsx
+++ b/src/components/links/__tests__/LinkStandalone-test.tsx
@@ -44,19 +44,6 @@ it('should support a left icon', async () => {
   await expect(container).toHaveNoA11yViolations();
 });
 
-it('should not show external icon when left icon is provided by default', () => {
-  setupWithMemoryRouter(
-    <LinkStandalone
-      iconLeft={<IconLink data-testid="link icon" />}
-      to="https://www.sonarsource.com">
-      link with icon
-    </LinkStandalone>,
-  );
-  expect(screen.getByRole('link')).toBeVisible();
-  expect(screen.getByTestId('link icon')).toBeInTheDocument();
-  expect(screen.queryByTestId('echoes-link-external-icon')).not.toBeInTheDocument();
-});
-
 it('should correclty support tooltips', async () => {
   const { user } = setupWithMemoryRouter(
     <Tooltip content="my tooltip">


### PR DESCRIPTION
I suggest we change linkbase to a simpler implementation where we extract the navlink part that is just for the DropdownMenuItemLink. It also allows to fully rely on the `shouldOpenInNewTab` props to display the external icon or not.