### PR TITLE
ECHOES-490 Support nested theme providers

### DIFF
--- a/design-tokens/build.js
+++ b/design-tokens/build.js
@@ -141,8 +141,8 @@ function buildThemedTokens(themedTokenGroups, baseDesignTokenGroup) {
                 fileHeader: 'licence-header',
                 selector:
                   theme.name === DEFAULT_THEME
-                    ? `:root, *[${THEME_DATA_ATTRIBUTE}='${theme.name}']`
-                    : `html[${THEME_DATA_ATTRIBUTE}='${theme.name}'], *[${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
+                    ? `:root, [${THEME_DATA_ATTRIBUTE}='${theme.name}']`
+                    : `html[${THEME_DATA_ATTRIBUTE}='${theme.name}'], [${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
               },
             },
             DEFAULT_THEME === theme.name && {

--- a/design-tokens/build.js
+++ b/design-tokens/build.js
@@ -142,7 +142,7 @@ function buildThemedTokens(themedTokenGroups, baseDesignTokenGroup) {
                 selector:
                   theme.name === DEFAULT_THEME
                     ? `:root, [${THEME_DATA_ATTRIBUTE}='${theme.name}']`
-                    : `[${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
+                    : `html[${THEME_DATA_ATTRIBUTE}='${theme.name}'], [${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
               },
             },
             DEFAULT_THEME === theme.name && {

--- a/design-tokens/build.js
+++ b/design-tokens/build.js
@@ -141,8 +141,8 @@ function buildThemedTokens(themedTokenGroups, baseDesignTokenGroup) {
                 fileHeader: 'licence-header',
                 selector:
                   theme.name === DEFAULT_THEME
-                    ? ':root'
-                    : `html[${THEME_DATA_ATTRIBUTE}='${theme.name}'], [${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
+                    ? `:root, [${THEME_DATA_ATTRIBUTE}='${theme.name}']`
+                    : `[${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
               },
             },
             DEFAULT_THEME === theme.name && {

--- a/design-tokens/build.js
+++ b/design-tokens/build.js
@@ -141,8 +141,8 @@ function buildThemedTokens(themedTokenGroups, baseDesignTokenGroup) {
                 fileHeader: 'licence-header',
                 selector:
                   theme.name === DEFAULT_THEME
-                    ? `:root, [${THEME_DATA_ATTRIBUTE}='${theme.name}']`
-                    : `html[${THEME_DATA_ATTRIBUTE}='${theme.name}'], [${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
+                    ? `:root, *[${THEME_DATA_ATTRIBUTE}='${theme.name}']`
+                    : `html[${THEME_DATA_ATTRIBUTE}='${theme.name}'], *[${THEME_DATA_ATTRIBUTE}='${theme.name}']`,
               },
             },
             DEFAULT_THEME === theme.name && {

--- a/design-tokens/build.js
+++ b/design-tokens/build.js
@@ -140,6 +140,12 @@ function buildThemedTokens(themedTokenGroups, baseDesignTokenGroup) {
               options: {
                 fileHeader: 'licence-header',
                 selector:
+                  /*
+                   * For any theme that is not the default theme, the `html`
+                   * attribute increases the specificity so that it can override
+                   * the default theme. Otherwise, the order in which the CSS
+                   * selectors appear in the CSS file would matter.
+                   */
                   theme.name === DEFAULT_THEME
                     ? `:root, [${THEME_DATA_ATTRIBUTE}='${theme.name}']`
                     : `html[${THEME_DATA_ATTRIBUTE}='${theme.name}'], [${THEME_DATA_ATTRIBUTE}='${theme.name}']`,

--- a/src/generated/design-tokens-dark.css
+++ b/src/generated/design-tokens-dark.css
@@ -20,7 +20,7 @@
  * GENERATED FILE: do not edit directly.
  */
 
-html[data-echoes-theme='dark'], [data-echoes-theme='dark'] {
+html[data-echoes-theme='dark'], *[data-echoes-theme='dark'] {
   --echoes-color-background-neutral: rgb(62,67,87);
   --echoes-color-background-neutral-bolder: rgb(99,113,146);
   --echoes-color-background-default: rgb(42,47,64);

--- a/src/generated/design-tokens-dark.css
+++ b/src/generated/design-tokens-dark.css
@@ -20,7 +20,7 @@
  * GENERATED FILE: do not edit directly.
  */
 
-html[data-echoes-theme='dark'], [data-echoes-theme='dark'] {
+[data-echoes-theme='dark'] {
   --echoes-color-background-neutral: rgb(62,67,87);
   --echoes-color-background-neutral-bolder: rgb(99,113,146);
   --echoes-color-background-default: rgb(42,47,64);

--- a/src/generated/design-tokens-dark.css
+++ b/src/generated/design-tokens-dark.css
@@ -20,7 +20,7 @@
  * GENERATED FILE: do not edit directly.
  */
 
-[data-echoes-theme='dark'] {
+html[data-echoes-theme='dark'], [data-echoes-theme='dark'] {
   --echoes-color-background-neutral: rgb(62,67,87);
   --echoes-color-background-neutral-bolder: rgb(99,113,146);
   --echoes-color-background-default: rgb(42,47,64);

--- a/src/generated/design-tokens-dark.css
+++ b/src/generated/design-tokens-dark.css
@@ -20,7 +20,7 @@
  * GENERATED FILE: do not edit directly.
  */
 
-html[data-echoes-theme='dark'], *[data-echoes-theme='dark'] {
+html[data-echoes-theme='dark'], [data-echoes-theme='dark'] {
   --echoes-color-background-neutral: rgb(62,67,87);
   --echoes-color-background-neutral-bolder: rgb(99,113,146);
   --echoes-color-background-default: rgb(42,47,64);

--- a/src/generated/design-tokens-light.css
+++ b/src/generated/design-tokens-light.css
@@ -20,7 +20,7 @@
  * GENERATED FILE: do not edit directly.
  */
 
-:root {
+:root, [data-echoes-theme='light'] {
   --echoes-color-background-neutral: rgb(239,242,249); /* Use it in components with neutral sentiment */
   --echoes-color-background-neutral-bolder: rgb(225,230,243); /* Use it in components with neutral sentiment that need a bolder highlight */
   --echoes-color-background-default: rgb(255,255,255); /* Go to color for backgrounds.. eg: cards, modals, popovers, etc... */

--- a/src/generated/design-tokens-light.css
+++ b/src/generated/design-tokens-light.css
@@ -20,7 +20,7 @@
  * GENERATED FILE: do not edit directly.
  */
 
-:root, [data-echoes-theme='light'] {
+:root, *[data-echoes-theme='light'] {
   --echoes-color-background-neutral: rgb(239,242,249); /* Use it in components with neutral sentiment */
   --echoes-color-background-neutral-bolder: rgb(225,230,243); /* Use it in components with neutral sentiment that need a bolder highlight */
   --echoes-color-background-default: rgb(255,255,255); /* Go to color for backgrounds.. eg: cards, modals, popovers, etc... */

--- a/src/generated/design-tokens-light.css
+++ b/src/generated/design-tokens-light.css
@@ -20,7 +20,7 @@
  * GENERATED FILE: do not edit directly.
  */
 
-:root, *[data-echoes-theme='light'] {
+:root, [data-echoes-theme='light'] {
   --echoes-color-background-neutral: rgb(239,242,249); /* Use it in components with neutral sentiment */
   --echoes-color-background-neutral-bolder: rgb(225,230,243); /* Use it in components with neutral sentiment that need a bolder highlight */
   --echoes-color-background-default: rgb(255,255,255); /* Go to color for backgrounds.. eg: cards, modals, popovers, etc... */

--- a/stories/ThemeProvider-stories.tsx
+++ b/stories/ThemeProvider-stories.tsx
@@ -1,0 +1,83 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/* eslint-disable no-console */
+import type { Meta, StoryObj } from '@storybook/react';
+import { Text, Theme, ThemeProvider } from '../src';
+import { basicWrapperDecorator } from './helpers/BasicWrapper';
+
+const meta: Meta<typeof ThemeProvider> = {
+  component: ThemeProvider,
+  title: 'Echoes/ThemeProvider',
+  argTypes: {
+    asChild: { control: { type: 'boolean' } },
+    theme: { control: { type: 'select' }, options: Object.values(Theme) },
+  },
+  args: {
+    asChild: false,
+    theme: Theme.light,
+  },
+  decorators: [basicWrapperDecorator],
+  render: ({ children, ...args }) => (
+    <ThemeProvider {...args}>
+      <div style={{ backgroundColor: 'var(--echoes-color-background-neutral)', padding: 24 }}>
+        <Text>{children}</Text>
+      </div>
+    </ThemeProvider>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ThemeProvider>;
+
+export const Default: Story = {
+  args: {
+    children: 'My Theme',
+  },
+};
+
+export const WithDarkTheme: Story = {
+  args: {
+    children: 'Dark Theme',
+    theme: Theme.dark,
+  },
+};
+
+export const WithNestedTheme: Story = {
+  args: {
+    children: 'Dark Theme',
+    theme: Theme.dark,
+  },
+  render: ({ children, ...args }) => (
+    <ThemeProvider {...args}>
+      <div style={{ backgroundColor: 'var(--echoes-color-background-neutral)', padding: 24 }}>
+        <div style={{ marginBottom: 24 }}>
+          <Text>{children}</Text>
+        </div>
+        <ThemeProvider theme={Theme.light}>
+          <div style={{ backgroundColor: 'var(--echoes-color-background-neutral)', padding: 24 }}>
+            <Text>Light Theme</Text>
+          </div>
+        </ThemeProvider>
+      </div>
+    </ThemeProvider>
+  ),
+};

--- a/stories/ThemeProvider-stories.tsx
+++ b/stories/ThemeProvider-stories.tsx
@@ -20,8 +20,17 @@
 
 /* eslint-disable no-console */
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentProps } from 'react';
 import { Text, Theme, ThemeProvider } from '../src';
 import { basicWrapperDecorator } from './helpers/BasicWrapper';
+
+function Background({ children, style }: ComponentProps<'div'>) {
+  return (
+    <div style={{ backgroundColor: 'var(--echoes-color-background-neutral)', ...style }}>
+      {children}
+    </div>
+  );
+}
 
 const meta: Meta<typeof ThemeProvider> = {
   component: ThemeProvider,
@@ -37,9 +46,9 @@ const meta: Meta<typeof ThemeProvider> = {
   decorators: [basicWrapperDecorator],
   render: ({ children, ...args }) => (
     <ThemeProvider {...args}>
-      <div style={{ backgroundColor: 'var(--echoes-color-background-neutral)', padding: 24 }}>
+      <Background style={{ padding: 24 }}>
         <Text>{children}</Text>
-      </div>
+      </Background>
     </ThemeProvider>
   ),
 };
@@ -68,16 +77,16 @@ export const WithNestedTheme: Story = {
   },
   render: ({ children, ...args }) => (
     <ThemeProvider {...args}>
-      <div style={{ backgroundColor: 'var(--echoes-color-background-neutral)', padding: 24 }}>
+      <Background style={{ padding: 24 }}>
         <div style={{ marginBottom: 24 }}>
           <Text>{children}</Text>
         </div>
         <ThemeProvider theme={Theme.light}>
-          <div style={{ backgroundColor: 'var(--echoes-color-background-neutral)', padding: 24 }}>
+          <Background style={{ padding: 24 }}>
             <Text>Light Theme</Text>
-          </div>
+          </Background>
         </ThemeProvider>
-      </div>
+      </Background>
     </ThemeProvider>
   ),
 };

--- a/stories/ThemeProvider-stories.tsx
+++ b/stories/ThemeProvider-stories.tsx
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-/* eslint-disable no-console */
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
 import { Text, Theme, ThemeProvider } from '../src';


### PR DESCRIPTION
**Theme Inception**

This PR adds support for nesting theme providers so that it is possible to render a subtree of components using the light theme within the context of a dark theme. For example,

```jsx
<ThemeProvider theme={Theme.Dark}>
  <Text>I should be dark theme</Text>
  <ThemeProvider theme={Theme.light}>
    <Text>I should be light theme</Text>
  </ThemeProvider>
</ThemeProvider>
```

![image](https://github.com/user-attachments/assets/401a0643-3319-4a50-91f5-e694f590b371)

This is achieved by making the following change to the generated CSS for the light theme,

```diff
- :root {
+ :root, [data-echoes-theme='light'] {
```

For a motivating example see https://github.com/SonarSource/sonarcloud-webapp/pull/1236.