### PR TITLE
ECHOES-533 Fix broken ids and a11y in DropdownMenu component

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -85,6 +85,14 @@ const DropdownMenuRoot = forwardRef<HTMLButtonElement, DropdownMenuRootProps>(
       return <>{children}</>;
     }
 
+    // Radix fully handles a11y binding with generated ids, but we have to do it manually because
+    // this id format is extensively used by SQS ITs to locate dropdown elements
+    // We can drop that and rely on Radix implem once we stop relying on ids in SQS ITs
+    const a11yAttrs = {
+      'aria-controls': `${id}-dropdown`,
+      id: `${id}-trigger`,
+    };
+
     return (
       <radixDropdownMenu.Root
         defaultOpen={isOpenOnMount}
@@ -97,7 +105,7 @@ const DropdownMenuRoot = forwardRef<HTMLButtonElement, DropdownMenuRootProps>(
           }
         }}
         open={isOpen}>
-        <radixDropdownMenu.Trigger asChild ref={ref} {...radixProps}>
+        <radixDropdownMenu.Trigger asChild ref={ref} {...a11yAttrs} {...radixProps}>
           {children}
         </radixDropdownMenu.Trigger>
 


### PR DESCRIPTION
[ECHOES-533](https://sonarsource.atlassian.net/browse/ECHOES-533)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[ECHOES-533]: https://sonarsource.atlassian.net/browse/ECHOES-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ