### PR TITLE
ECHOES-542 Align Checkbox

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -20,9 +20,10 @@
 
 import styled from '@emotion/styled';
 import * as RadixCheckbox from '@radix-ui/react-checkbox';
-import { forwardRef, useCallback } from 'react';
+import { forwardRef, useCallback, useId } from 'react';
 import { PropsWithLabels } from '~types/utils';
 import { Spinner } from '../spinner';
+import { HelperText } from '../typography';
 import { CheckboxIcon } from './CheckboxIcon';
 
 interface Props {
@@ -56,22 +57,20 @@ export const Checkbox = forwardRef<HTMLButtonElement, PropsWithLabels<Props>>((p
     ...radixProps
   } = props;
 
+  const defaultId = `${useId()}checkbox`;
+  const controlId = id ?? defaultId;
+
   const handleChange = useCallback(
     (checked: boolean | 'indeterminate') => {
       if (!isDisabled && !isLoading) {
-        onCheck(checked, id);
+        onCheck(checked, controlId);
       }
     },
-    [isDisabled, isLoading, onCheck, id],
+    [controlId, isDisabled, isLoading, onCheck],
   );
 
   return (
-    <CheckboxContainer
-      {...radixProps}
-      aria-disabled={isDisabled}
-      as={label ? 'label' : 'span'}
-      className={className}
-      ref={ref}>
+    <CheckboxContainer className={className} data-disabled={isDisabled}>
       <CheckboxInnerContainer className={innerClassName}>
         <Spinner isLoading={isLoading}>
           <CheckboxRoot
@@ -79,21 +78,23 @@ export const Checkbox = forwardRef<HTMLButtonElement, PropsWithLabels<Props>>((p
             aria-label={ariaLabel ?? title}
             aria-labelledby={ariaLabelledBy}
             checked={checked}
-            id={id}
+            id={controlId}
             onCheckedChange={handleChange}
             onFocus={onFocus}
+            ref={ref}
             title={title}
             // We only support the error state for unchecked checkboxes for now
-            {...(hasError && checked === false ? { 'data-error': true } : {})}>
+            {...(hasError && checked === false ? { 'data-error': true } : {})}
+            {...radixProps}>
             <CheckboxIndicator>
               <CheckboxIcon checked={checked} />
             </CheckboxIndicator>
           </CheckboxRoot>
         </Spinner>
         {(label || helpText) && (
-          <LabelWrapper aria-disabled={isDisabled}>
-            {label && <Label>{label}</Label>}
-            {helpText && <HelpText>{helpText}</HelpText>}
+          <LabelWrapper>
+            {label && <Label htmlFor={controlId}>{label}</Label>}
+            {helpText && <HelperText>{helpText}</HelperText>}
           </LabelWrapper>
         )}
       </CheckboxInnerContainer>
@@ -106,7 +107,7 @@ const CheckboxContainer = styled.span`
   display: inline-flex;
   vertical-align: top;
 
-  &[aria-disabled='true'] {
+  &[data-disabled='true'] {
     pointer-events: none;
   }
 `;
@@ -185,19 +186,7 @@ const LabelWrapper = styled.span`
   margin-left: var(--echoes-dimension-space-100);
 `;
 
-const Label = styled.span`
+const Label = styled.label`
+  color: var(--echoes-color-text-default);
   font: var(--echoes-typography-others-label-medium);
-
-  [aria-disabled='true'] > & {
-    color: var(--echoes-color-text-disabled);
-  }
-`;
-
-const HelpText = styled.span`
-  font: var(--echoes-typography-others-helper-text);
-  color: var(--echoes-color-text-subdued);
-
-  [aria-disabled='true'] > & {
-    color: var(--echoes-color-text-disabled);
-  }
 `;

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -33,7 +33,7 @@ interface Props {
   innerClassName?: string;
   isDisabled?: boolean;
   isLoading?: boolean;
-  onCheck: (checked: boolean | 'indeterminate', id?: string) => void;
+  onCheck: (checked: boolean | 'indeterminate', id: string) => void;
   onFocus?: VoidFunction;
   title?: string;
 }

--- a/src/components/checkbox/__tests__/Checkbox-test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox-test.tsx
@@ -25,6 +25,8 @@ import { OmitPropsWithLabels, render } from '~common/helpers/test-utils';
 import { Tooltip } from '../../tooltip';
 import { Checkbox } from '../Checkbox';
 
+const checkboxIdMatcher = expect.stringMatching(/:r\d:checkbox/);
+
 it('should call check function when clicked without label', async () => {
   const onCheck = jest.fn();
   const { container, rerender, user } = setupCheckbox({
@@ -36,13 +38,13 @@ it('should call check function when clicked without label', async () => {
   });
 
   await user.click(screen.getByRole('checkbox', { name: 'me' }));
-  expect(onCheck).toHaveBeenCalledWith(true, undefined);
+  expect(onCheck).toHaveBeenCalledWith(true, checkboxIdMatcher);
   expect(screen.getByTitle('title')).toBeVisible();
   await expect(container).toHaveNoA11yViolations();
 
   rerender({ ariaLabel: undefined, checked: true });
   await user.click(screen.getByRole('checkbox', { name: 'title' }));
-  expect(onCheck).toHaveBeenCalledWith(false, undefined);
+  expect(onCheck).toHaveBeenCalledWith(false, checkboxIdMatcher);
   await expect(container).toHaveNoA11yViolations();
 });
 
@@ -51,11 +53,11 @@ it("should call check function when clicked on it's label", async () => {
   const { rerender, user } = setupCheckbox({ label: 'me', onCheck, checked: false });
 
   await user.click(screen.getByText('me'));
-  expect(onCheck).toHaveBeenCalledWith(true, undefined);
+  expect(onCheck).toHaveBeenCalledWith(true, checkboxIdMatcher);
 
   rerender({ checked: true });
   await user.click(screen.getByRole('checkbox', { name: 'me' }));
-  expect(onCheck).toHaveBeenCalledWith(false, undefined);
+  expect(onCheck).toHaveBeenCalledWith(false, checkboxIdMatcher);
 });
 
 it('should work with indeterminate state', async () => {
@@ -67,7 +69,7 @@ it('should work with indeterminate state', async () => {
   expect(screen.getByRole('checkbox', { name: 'me' })).toHaveAttribute('aria-checked', 'mixed');
 
   await user.click(screen.getByRole('checkbox', { name: 'me' }));
-  expect(onCheck).toHaveBeenCalledWith(true, undefined);
+  expect(onCheck).toHaveBeenCalledWith(true, checkboxIdMatcher);
 });
 
 it('should show a loading state', async () => {

--- a/stories/Checkbox-stories.tsx
+++ b/stories/Checkbox-stories.tsx
@@ -19,8 +19,8 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { ComponentProps, useEffect, useState } from 'react';
-import { Checkbox } from '../src';
+import { ComponentProps, forwardRef, useEffect, useState } from 'react';
+import { Checkbox, Tooltip } from '../src';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
@@ -100,19 +100,41 @@ export const LoadingState: Story = {
   render: (args) => <CheckboxState initialValue={args.checked} {...args} />,
 };
 
-function CheckboxState({
-  initialValue,
-  ...checkboxProps
-}: Partial<ComponentProps<typeof Checkbox>> & {
+export const WithTooltip: Story = {
+  args: {
+    checked: false,
+    label: "I'm a checkbox",
+    helpText: 'I have some help text',
+    onCheck: () => {},
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Tooltip content="test">
+        <div>
+          <CheckboxState initialValue={args.checked} {...args} />
+        </div>
+      </Tooltip>
+    </div>
+  ),
+};
+
+type CheckboxStateProps = Partial<ComponentProps<typeof Checkbox>> & {
   initialValue: boolean | 'indeterminate';
-}) {
-  const [checked, setChecked] = useState(initialValue);
-  useEffect(() => setChecked(initialValue), [initialValue]);
-  return (
-    <Checkbox
-      {...(checkboxProps as ComponentProps<typeof Checkbox>)}
-      checked={checked}
-      onCheck={setChecked}
-    />
-  );
-}
+};
+
+const CheckboxState = forwardRef<HTMLButtonElement, CheckboxStateProps>(
+  ({ initialValue, ...checkboxProps }, ref) => {
+    const [checked, setChecked] = useState(initialValue);
+    useEffect(() => setChecked(initialValue), [initialValue]);
+    return (
+      <Checkbox
+        {...(checkboxProps as ComponentProps<typeof Checkbox>)}
+        checked={checked}
+        onCheck={setChecked}
+        ref={ref}
+      />
+    );
+  },
+);
+
+CheckboxState.displayName = 'CheckboxState';

--- a/stories/Checkbox-stories.tsx
+++ b/stories/Checkbox-stories.tsx
@@ -108,13 +108,9 @@ export const WithTooltip: Story = {
     onCheck: () => {},
   },
   render: (args) => (
-    <div style={{ display: 'flex', alignItems: 'center' }}>
-      <Tooltip content="test">
-        <div>
-          <CheckboxState initialValue={args.checked} {...args} />
-        </div>
-      </Tooltip>
-    </div>
+    <Tooltip content="This is a checkbox with a tooltip">
+      <CheckboxState initialValue={args.checked} {...args} />
+    </Tooltip>
   ),
 };
 


### PR DESCRIPTION
[ECHOES-542](https://sonarsource.atlassian.net/browse/ECHOES-542)

#### Notes

The [Figma page](https://www.figma.com/design/wYk5yGLz6MYC2hdu70IGql/(0.13.0)-Form-Fields?node-id=80-200) for checkboxes has not been updated to remove the disabled state from the label and description.

#### Changes

- The checkbox will now always have an id. As consequence, the second argument to the `onCheck` callback will never be `undefined`.
- The `aria-disabled` property on the checkbox container was renamed to `data-disabled`.
- The container no longer renders as a label element. Now, the label renders as a label element. See [Wrapping Everything Inside \<label>](https://www.smashingmagazine.com/2023/02/guide-accessible-form-validation/#wrapping-everything-inside-label) for a justification.
- The disabled styles were removed from the label and description.
- The private `HelpText` component was removed and replaced with the `HelperText` component.
- `color: var(--echoes-color-text-default);` was added to the checkbox label

#### Breaking Changes

- The `ref` was moved from the checkbox container to the checkbox button.
- The `radixProps` was moved from the checkbox container to the checkbox button.

[ECHOES-542]: https://sonarsource.atlassian.net/browse/ECHOES-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ