### PR TITLE
ECHOES-382 ECHOES-62 Implement Form components

### DIFF
--- a/src/components/buttons/ButtonTypes.ts
+++ b/src/components/buttons/ButtonTypes.ts
@@ -31,10 +31,10 @@ export interface ButtonCommonProps extends HTMLButtonAttributesSubset {
   isDisabled?: boolean;
   isLoading?: boolean;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => unknown;
-  size?: ButtonSize;
+  size?: `${ButtonSize}`;
   shouldPreventDefault?: boolean;
   shouldStopPropagation?: boolean;
-  variety?: ButtonVariety;
+  variety?: `${ButtonVariety}`;
 }
 
 export enum ButtonSize {

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -145,7 +145,7 @@ const DropdownMenuRoot = forwardRef<HTMLButtonElement, DropdownMenuRootProps>(
 );
 DropdownMenuRoot.displayName = 'DropdownMenu.Root';
 
-export const DropdownMenu = {
+export const DropdownMenu = Object.assign(DropdownMenuRoot, {
   GroupLabel: DropdownMenuGroupLabel,
   ItemButton: DropdownMenuItemButton,
   ItemButtonCheckable: DropdownMenuItemButtonCheckable,
@@ -155,7 +155,7 @@ export const DropdownMenu = {
   Root: DropdownMenuRoot,
   Separator: DropdownMenuSeparator,
   SubMenu: DropdownMenuSubMenu,
-};
+});
 
 const StyledHeaderLabelAndHelpText = styled.div`
   display: flex;

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -152,7 +152,6 @@ export const DropdownMenu = Object.assign(DropdownMenuRoot, {
   ItemButtonDestructive: DropdownMenuItemButtonDestructive,
   ItemLink: DropdownMenuItemLink,
   ItemLinkDownload: DropdownMenuItemLinkDownload,
-  Root: DropdownMenuRoot,
   Separator: DropdownMenuSeparator,
   SubMenu: DropdownMenuSubMenu,
 });

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -143,7 +143,7 @@ const DropdownMenuRoot = forwardRef<HTMLButtonElement, DropdownMenuRootProps>(
     );
   },
 );
-DropdownMenuRoot.displayName = 'DropdownMenu.Root';
+DropdownMenuRoot.displayName = 'DropdownMenu';
 
 export const DropdownMenu = Object.assign(DropdownMenuRoot, {
   GroupLabel: DropdownMenuGroupLabel,

--- a/src/components/dropdown-menu/DropdownMenuItemBase.tsx
+++ b/src/components/dropdown-menu/DropdownMenuItemBase.tsx
@@ -21,6 +21,7 @@
 import styled from '@emotion/styled';
 import * as radixDropdownMenu from '@radix-ui/react-dropdown-menu';
 import { forwardRef, MouseEventHandler, ReactNode, useCallback } from 'react';
+import { TextNode } from '~types/utils';
 import { IconCheck } from '../icons/IconCheck';
 
 type CheckProps =
@@ -37,7 +38,7 @@ export type DropdownMenuItemBaseProps = CheckProps & {
   ariaLabel?: string;
   children: ReactNode;
   className?: string;
-  helpText?: JSX.Element | string;
+  helpText?: TextNode;
   isDisabled?: boolean;
   onClick?: MouseEventHandler<HTMLDivElement>;
   prefix?: ReactNode;

--- a/src/components/dropdown-menu/__tests__/DropdownMenu-test.tsx
+++ b/src/components/dropdown-menu/__tests__/DropdownMenu-test.tsx
@@ -31,7 +31,7 @@ const trigger = <button type="button">Trigger</button>;
 
 it('should render without items', async () => {
   const { container } = setupWithMemoryRouter(
-    <DropdownMenu.Root items={undefined}>{trigger}</DropdownMenu.Root>,
+    <DropdownMenu items={undefined}>{trigger}</DropdownMenu>,
   );
 
   await expect(container).toHaveNoA11yViolations();
@@ -41,13 +41,13 @@ it('should render without items', async () => {
 
 it('should render with items when isOpen', () => {
   setupWithMemoryRouter(
-    <DropdownMenu.Root
+    <DropdownMenu
       className="testClassName"
       header={{ helpText: 'Header help text', label: 'Header label' }}
       isOpen
       items={items}>
       {trigger}
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.getByText('Header label')).toBeVisible();
@@ -57,9 +57,9 @@ it('should render with items when isOpen', () => {
 
 it('should render with items when isOpenOnMount', () => {
   setupWithMemoryRouter(
-    <DropdownMenu.Root className="testClassName" isOpenOnMount items={items}>
+    <DropdownMenu className="testClassName" isOpenOnMount items={items}>
       {trigger}
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.getByText('An item')).toBeVisible();
@@ -67,9 +67,9 @@ it('should render with items when isOpenOnMount', () => {
 
 it('should render with items when clicked', async () => {
   const { user } = setupWithMemoryRouter(
-    <DropdownMenu.Root items={items}>
+    <DropdownMenu items={items}>
       <a href="/">Trigger</a>
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.queryByText('An item')).not.toBeInTheDocument();
@@ -87,9 +87,9 @@ it('should handle onOpen', async () => {
   const onOpen = jest.fn();
 
   const { user } = setupWithMemoryRouter(
-    <DropdownMenu.Root align={DropdownMenuAlign.Start} items={items} onOpen={onOpen}>
+    <DropdownMenu align={DropdownMenuAlign.Start} items={items} onOpen={onOpen}>
       <a href="/">Trigger</a>
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.queryByText('An item')).not.toBeInTheDocument();
@@ -105,9 +105,9 @@ it('should handle onClose', async () => {
   const onClose = jest.fn();
 
   const { user } = setupWithMemoryRouter(
-    <DropdownMenu.Root align={DropdownMenuAlign.Center} items={items} onClose={onClose}>
+    <DropdownMenu align={DropdownMenuAlign.Center} items={items} onClose={onClose}>
       <a href="/">Trigger</a>
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.queryByText('An item')).not.toBeInTheDocument();
@@ -125,9 +125,9 @@ it('should handle onClose', async () => {
 
 it('should not show items when clicked if isDisabled', async () => {
   const { user } = setupWithMemoryRouter(
-    <DropdownMenu.Root align={DropdownMenuAlign.End} isDisabled items={items}>
+    <DropdownMenu align={DropdownMenuAlign.End} isDisabled items={items}>
       {trigger}
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.queryByText('An item')).not.toBeInTheDocument();
@@ -142,7 +142,7 @@ it('should render many different items', async () => {
   const linkClickHandler = jest.fn();
 
   const { user } = setupWithMemoryRouter(
-    <DropdownMenu.Root
+    <DropdownMenu
       isOpen
       items={
         <>
@@ -251,7 +251,7 @@ it('should render many different items', async () => {
         </>
       }>
       {trigger}
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(buttonClickHandler).not.toHaveBeenCalled();
@@ -275,9 +275,9 @@ it('should render many different items', async () => {
 it('should properly handle theme overrides', () => {
   setupWithMemoryRouter(
     <ThemeProvider theme={Theme.dark}>
-      <DropdownMenu.Root className="testClassName" isOpenOnMount items={items}>
+      <DropdownMenu className="testClassName" isOpenOnMount items={items}>
         {trigger}
-      </DropdownMenu.Root>
+      </DropdownMenu>
     </ThemeProvider>,
   );
 
@@ -286,7 +286,7 @@ it('should properly handle theme overrides', () => {
 
 it('should render with a sub-menu', () => {
   setupWithMemoryRouter(
-    <DropdownMenu.Root
+    <DropdownMenu
       className="testClassName"
       header={{ helpText: 'Header help text', label: 'Header label' }}
       isOpen
@@ -296,7 +296,7 @@ it('should render with a sub-menu', () => {
         </DropdownMenu.SubMenu>
       }>
       {trigger}
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.getByText('An item')).toBeVisible();

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -19,6 +19,7 @@
  */
 import styled from '@emotion/styled';
 import { type ComponentProps, type JSX, forwardRef } from 'react';
+import { TextNodeOptional } from '~types/utils';
 import { MessageInline, MessageInlineSize, MessageType } from '../messages';
 import { HelperText } from '../typography';
 import { FormFieldLabel } from './FormFieldLabel';
@@ -133,18 +134,17 @@ export enum FormFieldWidth {
   Full = 'full',
 }
 
-type Message = JSX.Element | string | false | null;
 type WhiteListedProps = Pick<ComponentProps<'div'>, 'className'>;
 
 export interface ValidationProps {
   /**
    * The message to display when the form field is invalid (optional).
    */
-  messageInvalid?: Message;
+  messageInvalid?: TextNodeOptional;
   /**
    * The message to display when the form field is valid (optional).
    */
-  messageValid?: Message;
+  messageValid?: TextNodeOptional;
   /**
    * The validation state of the form field (optional). The default is `none`,
    * meaning the form field has not been explicitly validated.
@@ -165,7 +165,7 @@ interface FormFieldProps extends ValidationProps, WhiteListedProps {
   /**
    * A descriptive message for the form field (optional).
    */
-  description?: Message;
+  description?: TextNodeOptional;
   /**
    * The ID of the description for the form field (optional). Useful for
    * establishing a relationship between a description and a form control using
@@ -185,7 +185,7 @@ interface FormFieldProps extends ValidationProps, WhiteListedProps {
   /**
    * The label for the form field (optional).
    */
-  label?: JSX.Element | string;
+  label?: TextNodeOptional;
   /**
    * The ID of the label for the form field (optional).
    */

--- a/src/components/form/FormFieldLabel.tsx
+++ b/src/components/form/FormFieldLabel.tsx
@@ -18,11 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import styled from '@emotion/styled';
-import { type JSX, forwardRef } from 'react';
+import { forwardRef } from 'react';
+import { TextNodeOptional } from '~types/utils';
 import { Label } from '../typography';
 
 interface Props {
-  children?: JSX.Element | string;
+  children?: TextNodeOptional;
   /**
    * The ID of the form control that this label is associated with.
    */

--- a/src/components/form/FormFooter.tsx
+++ b/src/components/form/FormFooter.tsx
@@ -1,0 +1,51 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import styled from '@emotion/styled';
+import { forwardRef, ReactNode } from 'react';
+import { ButtonGroup } from '../buttons';
+
+export interface FormFooterProps {
+  /**
+   * Buttons to display at the bottom of the Form. They are wrapped in a `ButtonGroup` and aligned to
+   * the right of the Form. Make sure to always keep the primary action on the right.
+   */
+  children: ReactNode;
+  className?: string;
+}
+
+export const FormFooter = forwardRef<HTMLDivElement, FormFooterProps>(
+  ({ children, ...rest }, ref) => {
+    return (
+      <FormFooterWrapper>
+        <ButtonGroup ref={ref} {...rest}>
+          {children}
+        </ButtonGroup>
+      </FormFooterWrapper>
+    );
+  },
+);
+FormFooter.displayName = 'FormFooter';
+
+const FormFooterWrapper = styled.div`
+  order: 3; // Ensure the footer always appear last in the Form even if the dev scramble the order of components
+  display: flex;
+  justify-content: flex-end;
+`;
+FormFooterWrapper.displayName = 'FormFooterWrapper';

--- a/src/components/form/FormHeader.tsx
+++ b/src/components/form/FormHeader.tsx
@@ -1,0 +1,70 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import styled from '@emotion/styled';
+import { forwardRef, ReactNode } from 'react';
+import { TextNode, TextNodeOptional } from '~types/utils';
+import { Heading, HeadingSize, Text } from '../typography';
+
+export interface FormHeaderProps {
+  className?: string;
+  /**
+   * Optional description to display below the title. It's automatically wrapped in a `<Text>` component.
+   */
+  description?: TextNodeOptional;
+  /**
+   * Optional content to display under the title/description, can be anything.
+   */
+  extraContent?: ReactNode;
+  /**
+   * Title to display at the top of the Form. It's automatically wrapped in a `<Heading as="h1">` component.
+   */
+  title: TextNode;
+}
+
+export const FormHeader = forwardRef<HTMLDivElement, FormHeaderProps>((props, ref) => {
+  const { title, description, extraContent, ...rest } = props;
+  return (
+    <FormHeaderWrapper ref={ref} {...rest}>
+      <FormHeaderContent>
+        <Heading as="h1" size={HeadingSize.ExtraLarge}>
+          {title}
+        </Heading>
+        {description && <Text>{description}</Text>}
+      </FormHeaderContent>
+      {extraContent}
+    </FormHeaderWrapper>
+  );
+});
+FormHeader.displayName = 'FormHeader';
+
+const FormHeaderWrapper = styled.div`
+  order: 1; // Ensure the header always appear first in the Form even if the dev scramble the order of components
+  display: flex;
+  flex-direction: column;
+  gap: var(--echoes-dimension-space-200);
+`;
+FormHeaderWrapper.displayName = 'FormHeaderWrapper';
+
+const FormHeaderContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--echoes-dimension-space-100);
+`;
+FormHeaderContent.displayName = 'FormHeaderContent';

--- a/src/components/form/FormRoot.tsx
+++ b/src/components/form/FormRoot.tsx
@@ -1,0 +1,57 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import styled from '@emotion/styled';
+import { FormHTMLAttributes, forwardRef, ReactNode } from 'react';
+
+type FormAttributes = Pick<
+  FormHTMLAttributes<HTMLFormElement>,
+  'action' | 'method' | 'name' | 'target' | 'onReset' | 'onSubmit' | 'onInvalid'
+>;
+
+export interface FormRootProps extends FormAttributes {
+  /**
+   * The content of the `Form.Root`, only one mandatory `Form.Header`, multiple `Form.Section`
+   * and one mandatory `Form.Footer` are allowed.
+   */
+  children?: ReactNode;
+  /**
+   * `noValidate` attribute is added by default on the form to not use the browser form validation.
+   * Set this prop to `true` to remove the `noValidate` attribute.
+   */
+  shouldUseBrowserValidation?: boolean;
+}
+
+export const FormRoot = forwardRef<HTMLFormElement, FormRootProps>((props, ref) => {
+  const { children, shouldUseBrowserValidation = false, ...rest } = props;
+
+  return (
+    <FormStyled noValidate={!shouldUseBrowserValidation} ref={ref} {...rest}>
+      {children}
+    </FormStyled>
+  );
+});
+FormRoot.displayName = 'FormRoot';
+
+const FormStyled = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--echoes-dimension-space-300);
+`;
+FormStyled.displayName = 'FormStyled';

--- a/src/components/form/FormSection.tsx
+++ b/src/components/form/FormSection.tsx
@@ -1,0 +1,93 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import styled from '@emotion/styled';
+import { forwardRef, ReactNode, useId } from 'react';
+import { TextNodeOptional } from '~types/utils';
+import { Heading, HeadingSize, Text, TextSize } from '../typography';
+
+export interface FormSectionProps {
+  className?: string;
+  /**
+   * Any number of form controls. The available form control elements are `CheckboxGroup`,
+   * `RadioButtonGroup`, `Select`, `Textarea`, and `TextInput`.
+   */
+  children: ReactNode;
+  /**
+   * Optional description to display below the section title. It's automatically wrapped in a
+   * `<Text>` component.
+   */
+  description?: TextNodeOptional;
+  /**
+   * The ID of the section. If not provided, a unique ID will be generated.
+   */
+  id?: string;
+  /**
+   * Optional title to be displayed at the top of the section. It's automatically wrapped in a
+   * `<Heading as="h2">` component.
+   */
+  title?: TextNodeOptional;
+}
+
+export const FormSection = forwardRef<HTMLDivElement, FormSectionProps>(
+  ({ children, description, id, title, ...rest }, ref) => {
+    const defaultId = `${useId()}form-section`;
+    const sectionId = id ?? defaultId;
+    const titleId = `${sectionId}-title`;
+    const descriptionId = `${sectionId}-description`;
+    const labelledBy = title ? titleId : undefined;
+    const describedBy = description ? descriptionId : undefined;
+
+    return (
+      <FormSectionWrapper
+        aria-describedby={describedBy}
+        aria-labelledby={labelledBy}
+        id={sectionId}
+        ref={ref}
+        role="group"
+        {...rest}>
+        {(title || description) && (
+          <div>
+            {title && (
+              <Heading as="h2" hasMarginBottom id={titleId} size={HeadingSize.Medium}>
+                {title}
+              </Heading>
+            )}
+            {description && (
+              <Text id={descriptionId} size={TextSize.Small}>
+                {description}
+              </Text>
+            )}
+          </div>
+        )}
+        {children}
+      </FormSectionWrapper>
+    );
+  },
+);
+FormSection.displayName = 'FormSection';
+
+// According to https://www.w3.org/WAI/tutorials/forms/grouping/ we should use <fieldset> and <legend> to group form elements but it's hard to style so we rely on role=group instead
+const FormSectionWrapper = styled.div`
+  order: 2; // Ensure the section always appear between the header and footer in the Form even if the dev scramble the order of components
+  display: flex;
+  flex-direction: column;
+  gap: var(--echoes-dimension-space-300);
+`;
+FormSectionWrapper.displayName = 'FormSectionWrapper';

--- a/src/components/form/__tests__/Form-test.tsx
+++ b/src/components/form/__tests__/Form-test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '~common/helpers/test-utils';
+import { Form, FormRootProps } from '..';
+import { Button } from '../../buttons';
+
+it('displays a form with header, sections and footer', async () => {
+  setupForm();
+
+  expect(screen.getByRole('heading', { name: 'Form title' })).toBeInTheDocument();
+  expect(screen.getByText('Form description')).toBeInTheDocument();
+  expect(screen.getByText('Form extra content')).toBeInTheDocument();
+
+  expect(screen.getByRole('group', { name: 'Section 1' })).toBeInTheDocument();
+  expect(screen.getByRole('group', { name: 'Section 1' })).toHaveAccessibleDescription(
+    'Section 1 description',
+  );
+  expect(screen.getByRole('group', { name: '' })).toHaveTextContent('Section 2 content');
+  await expect(screen.getByRole('form')).toHaveNoA11yViolations();
+});
+
+it('should submit and reset the form', async () => {
+  const onSubmit = jest.fn().mockImplementation((e) => e.preventDefault());
+  const onReset = jest.fn();
+  const { user } = setupForm({ onSubmit, onReset });
+
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+  expect(onSubmit).toHaveBeenCalled();
+
+  await user.click(screen.getByRole('button', { name: 'Cancel' }));
+  expect(onReset).toHaveBeenCalled();
+});
+
+function setupForm(props: Partial<FormRootProps> = {}) {
+  return render(
+    <Form name="MyForm" {...props}>
+      <Form.Header
+        description="Form description"
+        extraContent="Form extra content"
+        title="Form title"
+      />
+      <Form.Section description="Section 1 description" title="Section 1">
+        Section 1 content
+      </Form.Section>
+      <Form.Section>Section 2 content</Form.Section>
+      <Form.Footer>
+        <Button type="reset">Cancel</Button>
+        <Button type="submit" variety="primary">
+          Submit
+        </Button>
+      </Form.Footer>
+    </Form>,
+  );
+}

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -17,4 +17,61 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+import { FormFooter } from './FormFooter';
+import { FormHeader } from './FormHeader';
+import { FormRoot } from './FormRoot';
+import { FormSection } from './FormSection';
+
 export { FormFieldValidation, FormFieldWidth } from './FormField';
+export { type FormFooterProps } from './FormFooter';
+export { type FormHeaderProps } from './FormHeader';
+export { type FormRootProps } from './FormRoot';
+export { type FormSectionProps } from './FormSection';
+
+/**
+ * {@link FormRoot | Form} is a form element that wrap {@link FormHeader | Form.Header},
+ * {@link FormSection | Form.Section} and {@link FormFooter | Form.Footer}.
+ * It provides a consistent layout for forms.
+ *
+ * **Permitted Content**
+ *
+ * Exactly one {@link FormHeader | Form.Header}, one {@link FormFooter | Form.Footer} and as many
+ * {@link FormSection | Form.Section} as needed in between the header and footer.
+ *
+ * **Example**
+ *
+ * ```tsx
+ *  <Form method="POST">
+ *    <Form.Header title="Form title" />
+ *    <Form.Section>
+ *      ...
+ *    </Form.Section>
+ *    <Form.Section>
+ *      ...
+ *    </Form.Section>
+ *    <Form.Footer>
+ *      <Button type="reset">Cancel</Button>
+ *      <Button type="submit" variety="primary">Confirm</Button>
+ *    </Form.Footer>
+ *  </Form>
+ * ```
+ */
+export const Form = Object.assign(FormRoot, {
+  /**
+   * {@link FormHeader | Form.Header} is used to display a title and optional description at the top of a form.
+   */
+  Header: FormHeader,
+  /**
+   * {@link FormSection | Form.Section} is used to group related form controls together. It can have
+   * a title and description and can contain multiple form controls.
+   *
+   * The available form control elements are `CheckboxGroup`, `RadioButtonGroup`, `Select`, `Textarea`,
+   * and `TextInput`.
+   */
+  Section: FormSection,
+  /**
+   * {@link FormFooter | Form.Footer} is used to display a group of buttons at the bottom of the form.
+   * The children should be `Button` components, they are automatically wrapped in a `ButtonGroup`.
+   */
+  Footer: FormFooter,
+});

--- a/src/components/links/LinkBase.tsx
+++ b/src/components/links/LinkBase.tsx
@@ -37,7 +37,7 @@ export enum LinkHighlight {
 export interface LinkProps extends Pick<RouterLinkProps, RouterNavLinkPropsAllowed> {
   children: React.ReactNode;
   className?: string;
-  highlight?: LinkHighlight;
+  highlight?: `${LinkHighlight}`;
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
   shouldBlurAfterClick?: boolean;
   shouldOpenInNewTab?: boolean;

--- a/src/components/links/LinkBaseStyled.tsx
+++ b/src/components/links/LinkBaseStyled.tsx
@@ -45,6 +45,7 @@ export const LinkBaseStyled = styled(LinkBase)`
   ${({ highlight = LinkHighlight.Accent }) => LinkBaseStyledHighlight[highlight]};
 
   color: var(--color);
+  font-weight: var(--echoes-font-weight-semi-bold);
   text-decoration-line: var(--echoes-text-decoration-underline);
   text-decoration-color: var(--color);
   text-decoration-style: solid;

--- a/src/components/links/LinkStandalone.tsx
+++ b/src/components/links/LinkStandalone.tsx
@@ -21,7 +21,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { forwardRef } from 'react';
-import { LinkHighlight } from '.';
 import { LinkProps } from './LinkBase';
 import { LinkBaseStyled } from './LinkBaseStyled';
 
@@ -43,18 +42,7 @@ const LinkStandaloneBase = forwardRef<HTMLAnchorElement, Props>((props, ref) => 
 
 LinkStandaloneBase.displayName = 'LinkStandaloneBase';
 
-const LinkStandaloneHighlight = {
-  [LinkHighlight.Accent]: css`
-    font-weight: var(--echoes-font-weight-semi-bold);
-  `,
-  [LinkHighlight.Default]: undefined,
-  [LinkHighlight.Subdued]: undefined,
-  [LinkHighlight.CurrentColor]: undefined,
-};
-
 export const LinkStandalone = styled(LinkStandaloneBase)`
-  ${({ highlight = LinkHighlight.Accent }) => LinkStandaloneHighlight[highlight]}
-
   text-decoration-line: var(--echoes-text-decoration-none);
 
   &:hover,

--- a/src/components/messages/MessageCallout.tsx
+++ b/src/components/messages/MessageCallout.tsx
@@ -41,7 +41,7 @@ export interface MessageProps {
   screenReaderPrefix?: string;
   text: ReactNode;
   title?: string;
-  type: MessageType;
+  type: `${MessageType}`;
 }
 
 export const MessageCallout = forwardRef<HTMLDivElement, MessageProps>((props, ref) => {

--- a/src/components/messages/MessageInline.tsx
+++ b/src/components/messages/MessageInline.tsx
@@ -28,8 +28,8 @@ interface Props {
   className?: string;
   id?: string;
   screenReaderPrefix?: string;
-  size?: MessageInlineSize;
-  type: MessageType;
+  size?: `${MessageInlineSize}`;
+  type: `${MessageType}`;
 }
 
 export const MessageInline = forwardRef<HTMLDivElement, PropsWithChildren<Props>>((props, ref) => {

--- a/src/components/messages/MessageScreenReaderPrefix.tsx
+++ b/src/components/messages/MessageScreenReaderPrefix.tsx
@@ -25,7 +25,7 @@ import { MessageType } from './MessageTypes';
 
 interface Props {
   screenReaderPrefix?: string;
-  type: MessageType;
+  type: `${MessageType}`;
 }
 
 export const MessageScreenReaderPrefix = forwardRef<HTMLSpanElement, Props>((props, ref) => {

--- a/src/components/modals/__tests__/Modal-test.tsx
+++ b/src/components/modals/__tests__/Modal-test.tsx
@@ -75,7 +75,7 @@ it('should render content and description and extra buttons', async () => {
 
 it('should be triggered by DropdownMenu Items', async () => {
   const { user } = render(
-    <DropdownMenu.Root
+    <DropdownMenu
       id="modal-trigger"
       items={
         <Modal content="Modal content" title="Modal title">
@@ -83,7 +83,7 @@ it('should be triggered by DropdownMenu Items', async () => {
         </Modal>
       }>
       <Button>Menu</Button>
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();

--- a/src/components/modals/__tests__/ModalAlert-test.tsx
+++ b/src/components/modals/__tests__/ModalAlert-test.tsx
@@ -68,7 +68,7 @@ it('should render content and secondaryButtonLabel', async () => {
 
 it('should be triggered by DropdownMenu Items', async () => {
   const { user } = render(
-    <DropdownMenu.Root
+    <DropdownMenu
       id="modal-trigger"
       items={
         <ModalAlert
@@ -80,7 +80,7 @@ it('should be triggered by DropdownMenu Items', async () => {
         </ModalAlert>
       }>
       <Button>Menu</Button>
-    </DropdownMenu.Root>,
+    </DropdownMenu>,
   );
 
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();

--- a/src/components/radio-button-group/RadioButtonGroup.tsx
+++ b/src/components/radio-button-group/RadioButtonGroup.tsx
@@ -41,7 +41,7 @@ interface Props extends ValidationProps {
   options: RadioOption[];
 
   // Group Props
-  alignment?: RadioButtonGroupAlignment;
+  alignment?: `${RadioButtonGroupAlignment}`;
   className?: string;
   defaultValue?: string;
   id?: string;

--- a/src/components/select/SelectItemCommons.tsx
+++ b/src/components/select/SelectItemCommons.tsx
@@ -21,7 +21,6 @@
 import styled from '@emotion/styled';
 import { ComboboxLikeRenderOptionInput } from '@mantine/core';
 import { ComponentType, useCallback } from 'react';
-import { isDefined } from '~common/helpers/types';
 import { IconCheck } from '..';
 import { SelectOption, SelectOptionType } from './SelectTypes';
 
@@ -50,7 +49,7 @@ export function useSelectOptionFunction(
           <SelectItemInner>
             {OptionComponent ? <OptionComponent {...optionComponentProps} /> : <span>{label}</span>}
 
-            {isDefined(helpText) && <SelectItemHelpText>{helpText}</SelectItemHelpText>}
+            {helpText && <SelectItemHelpText>{helpText}</SelectItemHelpText>}
           </SelectItemInner>
 
           {suffix}

--- a/src/components/select/SelectTypes.ts
+++ b/src/components/select/SelectTypes.ts
@@ -19,6 +19,7 @@
  */
 import { ComboboxItem } from '@mantine/core';
 import { ReactNode } from 'react';
+import { TextNodeOptional } from '~types/utils';
 
 export enum SelectHighlight {
   Default = 'default',
@@ -33,7 +34,7 @@ export enum SelectOptionType {
 export interface SelectOption extends ComboboxItem {
   prefix?: ReactNode;
   suffix?: ReactNode;
-  helpText?: JSX.Element | string;
+  helpText?: TextNodeOptional;
   group?: never;
 }
 

--- a/src/components/text-input/TextInputBase.tsx
+++ b/src/components/text-input/TextInputBase.tsx
@@ -25,6 +25,7 @@ type InputEventAttributesSubset =
   | 'onFocus'
   | 'onBlur'
   | 'onChange'
+  | 'onInvalid'
   | 'onKeyDown'
   | 'onKeyPress'
   | 'onKeyUp'

--- a/src/components/typography/Heading.tsx
+++ b/src/components/typography/Heading.tsx
@@ -34,8 +34,9 @@ type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
 interface Props {
   as: HeadingTag;
   className?: string;
+  id?: string;
   hasMarginBottom?: boolean;
-  size?: HeadingSize;
+  size?: `${HeadingSize}`;
 }
 
 export const Heading = forwardRef<HTMLDivElement, Readonly<PropsWithChildren<Props>>>(
@@ -61,7 +62,7 @@ const StyledHeading = styled.div<Required<Pick<Props, 'hasMarginBottom' | 'size'
   max-width: var(--echoes-sizes-typography-max-width-default);
 
   ${({ hasMarginBottom, size }) =>
-    hasMarginBottom ? `margin-bottom: ${bottomMarginByHeadingSize(size)}` : ''}
+    hasMarginBottom ? `margin-bottom: ${bottomMarginByHeadingSize({ size })}` : ''}
 `;
 
 function getHeadingFont({ size }: Required<Pick<Props, 'size'>>) {
@@ -76,8 +77,8 @@ const HEADING_TYPOGRAPHY_MAP = {
   [HeadingSize.ExtraLarge]: 'var(--echoes-typography-heading-xlarge)',
 };
 
-const bottomMarginByHeadingSize = (headingSize: HeadingSize) => {
-  switch (headingSize) {
+const bottomMarginByHeadingSize = ({ size }: Required<Pick<Props, 'size'>>) => {
+  switch (size) {
     case HeadingSize.Large:
       return 'var(--echoes-dimension-space-200)';
     case HeadingSize.ExtraLarge:

--- a/src/components/typography/Text.tsx
+++ b/src/components/typography/Text.tsx
@@ -34,8 +34,9 @@ type TextTags = 'span' | 'p' | 'div' | 'strong' | 'b' | 'em' | 'i';
 type Props = {
   as?: TextTags;
   className?: string;
+  id?: string;
   isHighlighted?: boolean;
-  size?: TextSize;
+  size?: `${TextSize}`;
 } & ColorProps;
 
 type ColorProps =

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -18,12 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { JSX } from 'react';
+
+export type TextNode = JSX.Element | string;
+export type TextNodeOptional = TextNode | false | null;
+
 export interface PropsLabel {
   ariaLabel?: string;
   ariaLabelledBy?: never;
   id?: string;
-  label: JSX.Element | string;
-  helpText?: JSX.Element | string | false | null;
+  label: TextNode;
+  helpText?: TextNodeOptional;
 }
 
 export interface PropsAriaLabel {

--- a/stories/Form-stories.tsx
+++ b/stories/Form-stories.tsx
@@ -18,51 +18,153 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import type { Meta, StoryObj } from '@storybook/react';
-import { Checkbox } from '../src/components/checkbox';
-import { IconCopy, IconSearch } from '../src/components/icons';
-import { TextInput } from '../src/components/text-input';
+import { ComponentProps, createRef, FormEvent, useCallback, useState } from 'react';
+import {
+  Button,
+  Form,
+  FormFieldValidation,
+  Link,
+  MessageCallout,
+  RadioButtonGroup,
+  Select,
+  TextInput,
+} from '../src';
 import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
-const meta: Meta<{}> = {
-  component: TextInput,
+const meta: Meta<typeof Form> = {
+  component: Form,
   title: 'Echoes/Forms',
   argTypes: {},
   decorators: [basicWrapperDecorator],
 };
 
-// eslint-disable-next-line import/no-default-export
 export default meta;
 
-type Story = StoryObj<{}>;
+type Story = StoryObj<typeof Form>;
 
-// Option 1 using component composition
 export const Default: Story = {
   args: {},
-  render: (_args) => (
-    <fieldset>
-      <TextInput
-        helpText="You password must contain at least 8 characters"
-        isRequired
-        label="Password"
-        messageInvalid="This is an inline error message"
-        messageValid="This is an inline success message"
-        {..._args}
-      />
-      <TextInput
-        helpText="Please re-enter your password"
-        isRequired
-        label="Confirm password"
-        messageInvalid="This is an inline error message"
-        messageValid="This is an inline success message"
-        prefix={<IconSearch />}
-        suffix={<IconCopy />}
-      />
-      <Checkbox
-        checked={false}
-        helpText="By checking this box, you hereby give MegaCorp exclusive rights to your person"
-        label="I agree to the terms and conditions"
-        onCheck={() => {}}
-      />
-    </fieldset>
-  ),
+  render: (args) => <FormWithValidation {...args} />,
 };
+
+function FormWithValidation(props: ComponentProps<typeof Form>) {
+  const emailInputRef = createRef<HTMLInputElement>();
+  const [countryValue, setCountryValue] = useState<string | null>(null);
+  const [countryValidation, setCountryValidation] = useState(FormFieldValidation.None);
+  const [emailValidation, setEmailValidation] = useState(FormFieldValidation.None);
+  const [emailMessageInvalid, setEmailMessageInvalid] = useState<string | undefined>();
+
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      if (emailInputRef.current?.validity.typeMismatch) {
+        setEmailValidation(FormFieldValidation.Invalid);
+        setEmailMessageInvalid('Please enter a valid email');
+      } else if (emailInputRef.current?.validity.valueMissing) {
+        setEmailValidation(FormFieldValidation.Invalid);
+        setEmailMessageInvalid('The email is mandatory');
+      } else if (emailInputRef.current?.value.endsWith('@sonarsource.com')) {
+        setEmailValidation(FormFieldValidation.Invalid);
+        setEmailMessageInvalid(
+          'Oh no! Not a SonarSourcer again! Only private emails allowed, sorry!',
+        );
+      } else if (emailInputRef.current?.validity.valid) {
+        setEmailValidation(FormFieldValidation.Valid);
+      }
+
+      if (!countryValue) {
+        setCountryValidation(FormFieldValidation.Invalid);
+      } else {
+        setCountryValidation(FormFieldValidation.Valid);
+      }
+    },
+    [countryValue, emailInputRef],
+  );
+
+  const onReset = useCallback(() => {
+    setEmailValidation(FormFieldValidation.None);
+    setCountryValidation(FormFieldValidation.None);
+  }, []);
+
+  const onEmailChange = useCallback(() => {
+    setEmailValidation(FormFieldValidation.None);
+  }, []);
+
+  const onCountryChange = useCallback((value: string | null) => {
+    setCountryValue(value);
+    setCountryValidation(FormFieldValidation.None);
+  }, []);
+
+  return (
+    <Form onReset={onReset} onSubmit={onSubmit} {...props}>
+      <Form.Header
+        description={
+          <>
+            Starting from 30€ per month for 100k private lines of code.{' '}
+            <Link to="">Learn more</Link>. Service is charged monthly in advance, after your 14 days
+            free trial. Cancel anytime.
+          </>
+        }
+        extraContent={
+          <MessageCallout
+            text="This is the flag message description, use it to provide additional information."
+            type="info"
+          />
+        }
+        title="Upgrade to the Team plan"
+      />
+      <Form.Section
+        description="The credit card and plan you choose will be billed to the organization - not your user account."
+        title="Billing information">
+        <TextInput
+          isRequired
+          label="Email address"
+          messageInvalid={emailMessageInvalid}
+          onChange={onEmailChange}
+          ref={emailInputRef}
+          type="email"
+          validation={emailValidation}
+        />
+        <Select
+          data={[
+            { label: 'United States', value: 'us' },
+            { label: 'Switzerland', value: 'ch' },
+            { label: 'France', value: 'fr' },
+          ]}
+          isRequired
+          label="Country"
+          messageInvalid="The country is mandatory"
+          onChange={onCountryChange}
+          placeholder="Choose a country..."
+          validation={countryValidation}
+          value={countryValue}
+        />
+        <RadioButtonGroup
+          alignment="horizontal"
+          label="Type of use"
+          options={[
+            { label: 'Business', value: 'business' },
+            { label: 'Personal', value: 'personal' },
+          ]}
+        />
+      </Form.Section>
+      <Form.Section
+        description="We need your address to calculate the VAT and to send you the invoice."
+        title="Address information">
+        <TextInput label="Address line 1" />
+        <TextInput label="Address line 2 (optional)" />
+        <div style={{ display: 'flex', flexDirection: 'row', gap: '24px' }}>
+          <TextInput label="Postal code" />
+          <TextInput label="City" />
+        </div>
+      </Form.Section>
+      <Form.Footer>
+        <Button type="reset">Cancel</Button>
+        <Button type="submit" variety="primary">
+          Confirm payment
+        </Button>
+      </Form.Footer>
+    </Form>
+  );
+}

--- a/stories/Modal-stories.tsx
+++ b/stories/Modal-stories.tsx
@@ -147,7 +147,7 @@ export const WithSelectAndDropdown: Story = {
         <div>
           <ControlledSelect />
           <br />
-          <DropdownMenu.Root
+          <DropdownMenu
             align={DropdownMenuAlign.Start}
             items={
               <>
@@ -162,7 +162,7 @@ export const WithSelectAndDropdown: Story = {
               </>
             }>
             <Button>Choose a link to actually do nothing</Button>
-          </DropdownMenu.Root>
+          </DropdownMenu>
         </div>
       }
       {...args}>
@@ -199,7 +199,7 @@ export const WithADropdownItemTrigger: Story = {
     title: 'My Modal title',
   },
   render: (args) => (
-    <DropdownMenu.Root
+    <DropdownMenu
       id="modal-trigger"
       items={
         <Modal content={<div>Modal content, anything can be set in there.</div>} {...args}>
@@ -207,6 +207,6 @@ export const WithADropdownItemTrigger: Story = {
         </Modal>
       }>
       <ButtonIcon Icon={IconMoreVertical} ariaLabel="Menu" />
-    </DropdownMenu.Root>
+    </DropdownMenu>
   ),
 };

--- a/stories/dropdown-menu/DropdownMenu-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenu-stories.tsx
@@ -32,8 +32,8 @@ import {
 import { BasicWrapper } from '../helpers/BasicWrapper';
 import { MenuButton } from '../helpers/MenuButton';
 
-const meta: Meta<typeof DropdownMenu.Root> = {
-  component: DropdownMenu.Root,
+const meta: Meta<typeof DropdownMenu> = {
+  component: DropdownMenu,
   title: 'Echoes/DropdownMenu',
   parameters: {
     controls: { exclude: ['children', 'id'] },
@@ -42,7 +42,7 @@ const meta: Meta<typeof DropdownMenu.Root> = {
 
 export default meta;
 
-type Story = StoryObj<typeof DropdownMenu.Root>;
+type Story = StoryObj<typeof DropdownMenu>;
 
 const StyledBadge = styled.span`
   background-color: var(--echoes-color-background-default-active);
@@ -119,19 +119,15 @@ export const MenuWithVariousItems: Story = {
   },
   render: (args) => (
     <BasicWrapper>
-      <DropdownMenu.Root {...args} className="it__test" items={items}>
+      <DropdownMenu {...args} className="it__test" items={items}>
         <MenuButton />
-      </DropdownMenu.Root>
+      </DropdownMenu>
 
       <br />
 
-      <DropdownMenu.Root
-        {...args}
-        align={DropdownMenuAlign.Start}
-        id="secondDropdown"
-        items={items}>
+      <DropdownMenu {...args} align={DropdownMenuAlign.Start} id="secondDropdown" items={items}>
         <LinkStandalone to="#">Menu link</LinkStandalone>
-      </DropdownMenu.Root>
+      </DropdownMenu>
     </BasicWrapper>
   ),
 };
@@ -140,9 +136,9 @@ export const MenuInADarkSideBar: Story = {
   render: () => (
     <ThemeProvider theme={Theme.dark}>
       <FakeDarkSideBar>
-        <DropdownMenu.Root align={DropdownMenuAlign.Start} items={items}>
+        <DropdownMenu align={DropdownMenuAlign.Start} items={items}>
           <MenuButton />
-        </DropdownMenu.Root>
+        </DropdownMenu>
       </FakeDarkSideBar>
     </ThemeProvider>
   ),

--- a/stories/dropdown-menu/DropdownMenuItemButton-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemButton-stories.tsx
@@ -105,11 +105,11 @@ function render({
 }: PropsWithChildren<ComponentProps<typeof DropdownMenu.ItemButton>>) {
   return (
     <BasicWrapper>
-      <DropdownMenu.Root
+      <DropdownMenu
         isOpen
         items={<DropdownMenu.ItemButton {...args}>{children}</DropdownMenu.ItemButton>}>
         <MenuButton />
-      </DropdownMenu.Root>
+      </DropdownMenu>
     </BasicWrapper>
   );
 }

--- a/stories/dropdown-menu/DropdownMenuItemButtonCheckable-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemButtonCheckable-stories.tsx
@@ -167,13 +167,13 @@ function render({
 }: PropsWithChildren<ComponentProps<typeof DropdownMenu.ItemButtonCheckable>>) {
   return (
     <BasicWrapper>
-      <DropdownMenu.Root
+      <DropdownMenu
         isOpen
         items={
           <DropdownMenu.ItemButtonCheckable {...args}>{children}</DropdownMenu.ItemButtonCheckable>
         }>
         <MenuButton />
-      </DropdownMenu.Root>
+      </DropdownMenu>
     </BasicWrapper>
   );
 }

--- a/stories/dropdown-menu/DropdownMenuItemButtonDestructive-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemButtonDestructive-stories.tsx
@@ -66,7 +66,7 @@ function render({
 }: PropsWithChildren<ComponentProps<typeof DropdownMenu.ItemButtonDestructive>>) {
   return (
     <BasicWrapper>
-      <DropdownMenu.Root
+      <DropdownMenu
         isOpen
         items={
           <DropdownMenu.ItemButtonDestructive {...args}>
@@ -74,7 +74,7 @@ function render({
           </DropdownMenu.ItemButtonDestructive>
         }>
         <MenuButton />
-      </DropdownMenu.Root>
+      </DropdownMenu>
     </BasicWrapper>
   );
 }

--- a/stories/dropdown-menu/DropdownMenuItemLink-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemLink-stories.tsx
@@ -168,11 +168,11 @@ export const Full: Story = {
 function render({ children, ...args }: PropsWithChildren<{ to: To }>) {
   return (
     <BasicWrapper>
-      <DropdownMenu.Root
+      <DropdownMenu
         isOpen
         items={<DropdownMenu.ItemLink {...args}>{children}</DropdownMenu.ItemLink>}>
         <MenuButton />
-      </DropdownMenu.Root>
+      </DropdownMenu>
     </BasicWrapper>
   );
 }

--- a/stories/dropdown-menu/DropdownMenuItemLinkDownload-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemLinkDownload-stories.tsx
@@ -73,11 +73,11 @@ function render({
 }: PropsWithChildren<ComponentProps<typeof DropdownMenu.ItemLinkDownload>>) {
   return (
     <BasicWrapper>
-      <DropdownMenu.Root
+      <DropdownMenu
         isOpen
         items={<DropdownMenu.ItemLinkDownload {...args}>{children}</DropdownMenu.ItemLinkDownload>}>
         <MenuButton />
-      </DropdownMenu.Root>
+      </DropdownMenu>
     </BasicWrapper>
   );
 }


### PR DESCRIPTION
* Introduction of the Form components FormRoot, FormHeader, FormSectiona and FormFooter, I took the composition approach but that mean a lot of liberty for the devs and we don't enforce much the rules that are written in jsdoc...
* I extracted the Message type form FormField to TextNodeOptional that I used in many other places
* I also updated some of the enum typing that I encounter to use the `${EnumType}` pattern
* I also fixed a bug ticket we had about links as I noticed while working on the Form story that it was still there and super quick fix

### Breaking Changes

#### DropdownMenu

* `Root` was removed from the `DropdownMenu` namespace. To migrate, replace `DropdownMenu.Root` with `DropdownMenu`.