### PR TITLE
ECHOES-568 Migration Fixes

### DIFF
--- a/src/components/select/SelectCommons.tsx
+++ b/src/components/select/SelectCommons.tsx
@@ -173,6 +173,15 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
           error={validation === FormFieldValidation.Invalid}
           filter={optionsFilter}
           id={controlId}
+          label={label}
+          labelProps={{
+            // We no longer use Mantine's InputLabel component. However, if we
+            // do not pass a `label` prop to the Select component, Mantine will
+            // render an `aria-label` on the OptionsDropdown component. This
+            // causes the input and the dropdown to have the same label, which
+            // is problematic for accessibility.
+            labelElement: Null,
+          }}
           leftSection={valueIcon}
           nothingFoundMessage={labelNotFound}
           onDropdownOpen={onOpen}
@@ -193,6 +202,10 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
     );
   },
 );
+
+function Null() {
+  return null;
+}
 
 SelectBase.displayName = 'SelectBase';
 


### PR DESCRIPTION
[ECHOES-568](https://sonarsource.atlassian.net/browse/ECHOES-568)

There are a bunch of tests failing in the product because Mantine is adding the same label to the input element and option dropdown wrapper element.

[ECHOES-568]: https://sonarsource.atlassian.net/browse/ECHOES-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ