### PR TITLE
ECHOES-569 Expose Component Prop Types

### DIFF
--- a/src/components/checkbox/index.ts
+++ b/src/components/checkbox/index.ts
@@ -17,4 +17,4 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-export { Checkbox } from './Checkbox';
+export { type CheckboxProps, Checkbox } from './Checkbox';

--- a/src/components/text-area/TextArea.tsx
+++ b/src/components/text-area/TextArea.tsx
@@ -34,12 +34,17 @@ type InputAttributes = Pick<
   'autoComplete' | 'autoFocus' | 'form' | 'maxLength' | 'minLength' | 'name' | 'readOnly'
 >;
 
-interface Props extends InputProps, InputAttributes, InputEventProps<HTMLTextAreaElement> {
+interface TextAreaPropsBase
+  extends InputProps,
+    InputAttributes,
+    InputEventProps<HTMLTextAreaElement> {
   isResizable?: boolean;
   rows?: number;
 }
 
-export const TextArea = forwardRef<HTMLTextAreaElement, PropsWithLabels<Props>>((props, ref) => {
+export type TextAreaProps = PropsWithLabels<TextAreaPropsBase>;
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => {
   const {
     ariaLabel,
     ariaLabelledBy,

--- a/src/components/text-area/index.ts
+++ b/src/components/text-area/index.ts
@@ -17,4 +17,4 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-export { TextArea } from './TextArea';
+export { type TextAreaProps, TextArea } from './TextArea';

--- a/src/components/text-input/TextInput.tsx
+++ b/src/components/text-input/TextInput.tsx
@@ -45,13 +45,18 @@ type InputAttributes = Pick<
   | 'step'
 >;
 
-interface Props extends InputProps, InputAttributes, InputEventProps<HTMLInputElement> {
+interface TextInputPropsBase
+  extends InputProps,
+    InputAttributes,
+    InputEventProps<HTMLInputElement> {
   prefix?: ReactNode;
   suffix?: ReactNode;
   type?: 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
 }
 
-export const TextInput = forwardRef<HTMLInputElement, PropsWithLabels<Props>>((props, ref) => {
+export type TextInputProps = PropsWithLabels<TextInputPropsBase>;
+
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, ref) => {
   const {
     ariaLabel,
     ariaLabelledBy,

--- a/src/components/text-input/index.ts
+++ b/src/components/text-input/index.ts
@@ -17,4 +17,4 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-export { TextInput } from './TextInput';
+export { type TextInputProps, TextInput } from './TextInput';


### PR DESCRIPTION
[ECHOES-569](https://sonarsource.atlassian.net/browse/ECHOES-569)

Some components were not exporting their prop types.

[ECHOES-569]: https://sonarsource.atlassian.net/browse/ECHOES-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ