### PR TITLE
ECHOES-581 Remove the extra bottom margin to form/section headers when there is no description

### DIFF
--- a/src/components/form/FormHeader.tsx
+++ b/src/components/form/FormHeader.tsx
@@ -51,7 +51,7 @@ export const FormHeader = forwardRef<HTMLDivElement, FormHeaderProps>((props, re
   return (
     <FormHeaderWrapper ref={ref} {...rest}>
       <FormHeaderContent>
-        <Heading as={titleAs} hasMarginBottom size={titleSize}>
+        <Heading as={titleAs} hasMarginBottom={Boolean(description)} size={titleSize}>
           {title}
         </Heading>
         {description && <Text>{description}</Text>}

--- a/src/components/form/FormSection.tsx
+++ b/src/components/form/FormSection.tsx
@@ -73,7 +73,11 @@ export const FormSection = forwardRef<HTMLDivElement, FormSectionProps>((props, 
       {(title || description) && (
         <div>
           {title && (
-            <Heading as={titleAs} hasMarginBottom id={titleId} size={titleSize}>
+            <Heading
+              as={titleAs}
+              hasMarginBottom={Boolean(description)}
+              id={titleId}
+              size={titleSize}>
               {title}
             </Heading>
           )}


### PR DESCRIPTION
[ECHOES-581](https://sonarsource.atlassian.net/browse/ECHOES-581)

Part of ECHOES-455


It fixes this issue: 
![image](https://github.com/user-attachments/assets/b707afa0-9dc1-4ced-a098-edc6bd13dd79)



[ECHOES-581]: https://sonarsource.atlassian.net/browse/ECHOES-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ