### PR TITLE
ECHOES-583 Add helpToggletip prop to form fields

### DIFF
--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -25,8 +25,8 @@ import { type CheckboxProps, Checkbox } from '../checkbox/Checkbox';
 import {
   type ValidationProps,
   FormField,
+  FormFieldProps,
   FormFieldValidation,
-  FormFieldWidth,
 } from '../form/FormField';
 import { useFormFieldA11y } from '../form/useFormFieldA11y';
 
@@ -77,6 +77,7 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
       ariaLabelledBy,
       className,
       helpText,
+      helpToggletip,
       id,
       isDisabled,
       isRequired,
@@ -109,6 +110,7 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
         className={className}
         helpText={helpText}
         helpTextId={helpTextId}
+        helpToggletip={helpToggletip}
         isDisabled={isDisabled}
         isRequired={isRequired}
         label={label}
@@ -186,7 +188,12 @@ type CheckboxOption<T = unknown> = Pick<
   value?: T;
 };
 
-interface CheckboxGroupPropsBase<T> extends RefAttributes<HTMLDivElement>, ValidationProps {
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'isRequired' | 'width'>;
+
+interface CheckboxGroupPropsBase<T>
+  extends RefAttributes<HTMLDivElement>,
+    ValidationProps,
+    FormFieldPropsSubset {
   /**
    * Controls the alignment of the checkboxes in the group (optional). The
    * default is `vertical`.
@@ -204,11 +211,6 @@ interface CheckboxGroupPropsBase<T> extends RefAttributes<HTMLDivElement>, Valid
    * Prevent the user from interacting with the checkboxes (optional).
    */
   isDisabled?: boolean;
-  /**
-   * When true, an asterisk will be displayed next to the label to indicate that
-   * the field is required.
-   */
-  isRequired?: boolean;
   /**
    * You may provide a name for the group that is used when submitting a form
    * (optional). The value of the field will be a comma separated list of the
@@ -237,11 +239,6 @@ interface CheckboxGroupPropsBase<T> extends RefAttributes<HTMLDivElement>, Valid
    * assumed to be unique.
    */
   value: T[];
-  /**
-   * Controls the width of the form field (optional). The default value is
-   * `full`, meaning it will take up the full width of its container.
-   */
-  width?: `${FormFieldWidth}`;
 }
 
 export type CheckboxGroupProps<T = unknown> = PropsWithLabels<CheckboxGroupPropsBase<T>>;

--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -77,7 +77,7 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
       ariaLabelledBy,
       className,
       helpText,
-      helpToggletip,
+      helpToggletipProps,
       id,
       isDisabled,
       isRequired,
@@ -97,7 +97,7 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
 
     const { controlId, describedBy, helpTextId, labelId, validationMessageId } = useFormFieldA11y({
       controlId: id ?? defaultId,
-      hasDescription: Boolean(helpText),
+      hasHelpText: Boolean(helpText),
       hasValidationMessage: Boolean(messageInvalid || messageValid),
     });
 
@@ -110,7 +110,7 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
         className={className}
         helpText={helpText}
         helpTextId={helpTextId}
-        helpToggletip={helpToggletip}
+        helpToggletipProps={helpToggletipProps}
         isDisabled={isDisabled}
         isRequired={isRequired}
         label={label}
@@ -188,7 +188,7 @@ type CheckboxOption<T = unknown> = Pick<
   value?: T;
 };
 
-type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'isRequired' | 'width'>;
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletipProps' | 'isRequired' | 'width'>;
 
 interface CheckboxGroupPropsBase<T>
   extends RefAttributes<HTMLDivElement>,

--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -94,12 +94,11 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
 
     const defaultId = `${useId()}checkbox_group`;
 
-    const { controlId, describedBy, descriptionId, labelId, validationMessageId } =
-      useFormFieldA11y({
-        controlId: id ?? defaultId,
-        hasDescription: Boolean(helpText),
-        hasValidationMessage: Boolean(messageInvalid || messageValid),
-      });
+    const { controlId, describedBy, helpTextId, labelId, validationMessageId } = useFormFieldA11y({
+      controlId: id ?? defaultId,
+      hasDescription: Boolean(helpText),
+      hasValidationMessage: Boolean(messageInvalid || messageValid),
+    });
 
     const serializedValue = useMemo(() => {
       return name ? value.map(serializeValue) : [];
@@ -108,8 +107,8 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
     return (
       <FormField
         className={className}
-        description={helpText}
-        descriptionId={descriptionId}
+        helpText={helpText}
+        helpTextId={helpTextId}
         isDisabled={isDisabled}
         isRequired={isRequired}
         label={label}

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -55,7 +55,7 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
     controlId,
     helpText,
     helpTextId,
-    helpToggletip,
+    helpToggletipProps,
     isDisabled = false,
     isRequired = false,
     label,
@@ -87,7 +87,7 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
       ref={ref}
       {...rest}>
       <FormFieldLabel
-        helpToggletip={helpToggletip}
+        helpToggletipProps={helpToggletipProps}
         htmlFor={controlId}
         id={labelId}
         isRequired={isRequired}>
@@ -99,9 +99,9 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
         {messageValidElement}
       </span>
       {helpText && (
-        <Description hidden={Boolean(messageValidElement || messageInvalidElement)} id={helpTextId}>
+        <HelpText hidden={Boolean(messageValidElement || messageInvalidElement)} id={helpTextId}>
           {helpText}
-        </Description>
+        </HelpText>
       )}
     </FormFieldStyled>
   );
@@ -196,7 +196,7 @@ export interface FormFieldProps extends ValidationProps, WhiteListedProps {
   /**
    * The props for a help toggletip showing next to the form field label to provide additional information about the field (optional).
    */
-  helpToggletip?: FormFieldLabelProps['helpToggletip'];
+  helpToggletipProps?: FormFieldLabelProps['helpToggletipProps'];
   /**
    * The ID of the validation message for the form field (optional). Useful for
    * establishing a relationship between a validation message and a form control
@@ -234,8 +234,8 @@ const ValidationMessage = styled(MessageInline)`
 
 ValidationMessage.displayName = 'ValidationMessage';
 
-const Description = styled(HelperText)`
+const HelpText = styled(HelperText)`
   margin-top: var(--echoes-dimension-space-75);
 `;
 
-Description.displayName = 'Description';
+HelpText.displayName = 'HelpText';

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -38,7 +38,7 @@ import { FormFieldLabel } from './FormFieldLabel';
  * ```tsx
  * <FormField
  *   controlId="19ujfsyw"
- *   description="Please provide your full name"
+ *   helpText="Please provide your full name"
  *   isRequired
  *   label="Full name"
  *   massageInvalid="Your name is required"
@@ -53,8 +53,8 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
   const {
     children,
     controlId,
-    description,
-    descriptionId,
+    helpText,
+    helpTextId,
     isDisabled = false,
     isRequired = false,
     label,
@@ -93,11 +93,9 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
         {messageInvalidElement}
         {messageValidElement}
       </span>
-      {description && (
-        <Description
-          hidden={Boolean(messageValidElement || messageInvalidElement)}
-          id={descriptionId}>
-          {description}
+      {helpText && (
+        <Description hidden={Boolean(messageValidElement || messageInvalidElement)} id={helpTextId}>
+          {helpText}
         </Description>
       )}
     </FormFieldStyled>
@@ -163,15 +161,15 @@ interface FormFieldProps extends ValidationProps, WhiteListedProps {
    */
   controlId?: string;
   /**
-   * A descriptive message for the form field (optional).
+   * A descriptive message for the form field, provides more context about the input validation and criteria (optional).
    */
-  description?: TextNodeOptional;
+  helpText?: TextNodeOptional;
   /**
    * The ID of the description for the form field (optional). Useful for
    * establishing a relationship between a description and a form control using
    * the `aria-describedby` attribute.
    */
-  descriptionId?: string;
+  helpTextId?: string;
   /**
    * When true, pointer events will be disabled on the label to prevent
    * activating the form control.
@@ -190,6 +188,10 @@ interface FormFieldProps extends ValidationProps, WhiteListedProps {
    * The ID of the label for the form field (optional).
    */
   labelId?: string;
+  /**
+   * A toggletip showing next to the form field label to provide additional information about the field (optional).
+   */
+  toggleTip?: TextNodeOptional;
   /**
    * The ID of the validation message for the form field (optional). Useful for
    * establishing a relationship between a validation message and a form control

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -22,7 +22,7 @@ import { type ComponentProps, type JSX, forwardRef } from 'react';
 import { TextNodeOptional } from '~types/utils';
 import { MessageInline, MessageInlineSize, MessageType } from '../messages';
 import { HelperText } from '../typography';
-import { FormFieldLabel } from './FormFieldLabel';
+import { FormFieldLabel, FormFieldLabelProps } from './FormFieldLabel';
 
 /**
  * Form fields wrap form controls and help create standardization between them.
@@ -55,6 +55,7 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
     controlId,
     helpText,
     helpTextId,
+    helpToggletip,
     isDisabled = false,
     isRequired = false,
     label,
@@ -85,7 +86,11 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
       data-width={width}
       ref={ref}
       {...rest}>
-      <FormFieldLabel htmlFor={controlId} id={labelId} isRequired={isRequired}>
+      <FormFieldLabel
+        helpToggletip={helpToggletip}
+        htmlFor={controlId}
+        id={labelId}
+        isRequired={isRequired}>
         {label}
       </FormFieldLabel>
       {children}
@@ -150,7 +155,7 @@ export interface ValidationProps {
   validation?: `${FormFieldValidation}`;
 }
 
-interface FormFieldProps extends ValidationProps, WhiteListedProps {
+export interface FormFieldProps extends ValidationProps, WhiteListedProps {
   /**
    * The form control element. A form field should have exactly one form control.
    */
@@ -179,19 +184,19 @@ interface FormFieldProps extends ValidationProps, WhiteListedProps {
    * When true, an asterisk will be displayed next to the label to indicate that
    * the field is required.
    */
-  isRequired?: boolean;
+  isRequired?: FormFieldLabelProps['isRequired'];
   /**
    * The label for the form field (optional).
    */
-  label?: TextNodeOptional;
+  label?: FormFieldLabelProps['children'];
   /**
    * The ID of the label for the form field (optional).
    */
-  labelId?: string;
+  labelId?: FormFieldLabelProps['id'];
   /**
-   * A toggletip showing next to the form field label to provide additional information about the field (optional).
+   * The props for a help toggletip showing next to the form field label to provide additional information about the field (optional).
    */
-  toggleTip?: TextNodeOptional;
+  helpToggletip?: FormFieldLabelProps['helpToggletip'];
   /**
    * The ID of the validation message for the form field (optional). Useful for
    * establishing a relationship between a validation message and a form control

--- a/src/components/form/FormFieldLabel.tsx
+++ b/src/components/form/FormFieldLabel.tsx
@@ -20,9 +20,11 @@
 import styled from '@emotion/styled';
 import { forwardRef } from 'react';
 import { TextNodeOptional } from '~types/utils';
+import { PopoverSide } from '../popover';
+import { ToggleTip, ToggleTipProps } from '../toggle-tip';
 import { Label } from '../typography';
 
-interface Props {
+export interface FormFieldLabelProps {
   children?: TextNodeOptional;
   /**
    * The ID of the form control that this label is associated with.
@@ -36,6 +38,10 @@ interface Props {
    * When true, will display an asterisk to indicate that the field is required.
    */
   isRequired?: boolean;
+  /**
+   * The props for a help toggletip showing next to the form field label to provide additional information about the field (optional).
+   */
+  helpToggletip?: ToggleTipProps;
 }
 
 /**
@@ -51,29 +57,40 @@ interface Props {
  *
  * @internal
  */
-export const FormFieldLabel = forwardRef<HTMLLabelElement, Props>((props, ref) => {
-  const { children, isRequired = false, ...rest } = props;
+export const FormFieldLabel = forwardRef<HTMLLabelElement, FormFieldLabelProps>((props, ref) => {
+  const { children, isRequired = false, helpToggletip, ...rest } = props;
 
   if (!children) {
     return null;
   }
 
   return (
-    <LabelStyled ref={ref} {...rest}>
-      {children}
-      {isRequired && <RequiredIndicator aria-hidden="true">*</RequiredIndicator>}
-    </LabelStyled>
+    <LabelWrapper>
+      <LabelStyled ref={ref} {...rest}>
+        {children}
+        {isRequired && <RequiredIndicator aria-hidden="true">*</RequiredIndicator>}
+      </LabelStyled>
+      {helpToggletip && <ToggleTip side={PopoverSide.Right} {...helpToggletip} />}
+    </LabelWrapper>
   );
 });
 
 FormFieldLabel.displayName = 'FormFieldLabel';
 
+const LabelWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--echoes-dimension-space-75);
+
+  margin-bottom: var(--echoes-dimension-space-75);
+`;
+LabelWrapper.displayName = 'LabelWrapper';
+
 const LabelStyled = styled(Label)`
   display: block;
   inline-size: fit-content;
-  margin-bottom: var(--echoes-dimension-space-75);
 
-  [data-disabled] > & {
+  [data-disabled] & {
     pointer-events: none;
   }
 `;

--- a/src/components/form/FormFieldLabel.tsx
+++ b/src/components/form/FormFieldLabel.tsx
@@ -41,7 +41,7 @@ export interface FormFieldLabelProps {
   /**
    * The props for a help toggletip showing next to the form field label to provide additional information about the field (optional).
    */
-  helpToggletip?: ToggleTipProps;
+  helpToggletipProps?: ToggleTipProps;
 }
 
 /**
@@ -58,7 +58,7 @@ export interface FormFieldLabelProps {
  * @internal
  */
 export const FormFieldLabel = forwardRef<HTMLLabelElement, FormFieldLabelProps>((props, ref) => {
-  const { children, isRequired = false, helpToggletip, ...rest } = props;
+  const { children, isRequired = false, helpToggletipProps, ...rest } = props;
 
   if (!children) {
     return null;
@@ -70,7 +70,7 @@ export const FormFieldLabel = forwardRef<HTMLLabelElement, FormFieldLabelProps>(
         {children}
         {isRequired && <RequiredIndicator aria-hidden="true">*</RequiredIndicator>}
       </LabelStyled>
-      {helpToggletip && <ToggleTip side={PopoverSide.Right} {...helpToggletip} />}
+      {helpToggletipProps && <ToggleTip side={PopoverSide.Right} {...helpToggletipProps} />}
     </LabelWrapper>
   );
 });

--- a/src/components/form/__tests__/FormField-test.tsx
+++ b/src/components/form/__tests__/FormField-test.tsx
@@ -45,7 +45,10 @@ it('displays an asterisk next to the label if the form field is required', () =>
 
 it('displays a help toggletip next to the label', async () => {
   const { user } = render(
-    <FormField controlId="foo" helpToggletip={{ description: 'Help toggletip' }} label="Label 2">
+    <FormField
+      controlId="foo"
+      helpToggletipProps={{ description: 'Help toggletip' }}
+      label="Label 2">
       <input id="foo" />
     </FormField>,
   );

--- a/src/components/form/__tests__/FormField-test.tsx
+++ b/src/components/form/__tests__/FormField-test.tsx
@@ -65,7 +65,7 @@ it('sets the for attribute on the label if a control ID is provided', () => {
 
 it('has no a11y violations', async () => {
   const { container } = render(
-    <FormField controlId="input" description="Help text" label="Label">
+    <FormField controlId="input" helpText="Help text" label="Label">
       <input id="input" />
     </FormField>,
   );
@@ -74,7 +74,7 @@ it('has no a11y violations', async () => {
 
 it('displays a description if one is provided', () => {
   render(
-    <FormField description="Description text 1">
+    <FormField helpText="Description text 1">
       <input />
     </FormField>,
   );
@@ -87,7 +87,7 @@ it.each([FormFieldValidation.Invalid, FormFieldValidation.Valid])(
   (validation) => {
     render(
       <FormField
-        description="Description text 2"
+        helpText="Description text 2"
         messageInvalid="💣"
         messageValid="😎"
         validation={validation}>
@@ -103,7 +103,7 @@ it.each([FormFieldValidation.Invalid, FormFieldValidation.Valid])(
   'displays the description if the form field validation is %s and no validation message is provided',
   (validation) => {
     render(
-      <FormField description="Description text 3" validation={validation}>
+      <FormField helpText="Description text 3" validation={validation}>
         <input />
       </FormField>,
     );
@@ -114,7 +114,7 @@ it.each([FormFieldValidation.Invalid, FormFieldValidation.Valid])(
 
 it('sets the id on the description if one is provided', () => {
   render(
-    <FormField description="Description text 4" descriptionId="foo">
+    <FormField helpText="Description text 4" helpTextId="foo">
       <input />
     </FormField>,
   );

--- a/src/components/form/__tests__/FormField-test.tsx
+++ b/src/components/form/__tests__/FormField-test.tsx
@@ -43,6 +43,17 @@ it('displays an asterisk next to the label if the form field is required', () =>
   expect(label).toBeVisible();
 });
 
+it('displays a help toggletip next to the label', async () => {
+  const { user } = render(
+    <FormField controlId="foo" helpToggletip={{ description: 'Help toggletip' }} label="Label 2">
+      <input id="foo" />
+    </FormField>,
+  );
+
+  await user.click(screen.getByLabelText('More information'));
+  expect(screen.getByText('Help toggletip')).toBeVisible();
+});
+
 it('disables pointer events on the label if the form field is disabled', () => {
   render(
     <FormField isDisabled label="Label 3">

--- a/src/components/form/useFormFieldA11y.ts
+++ b/src/components/form/useFormFieldA11y.ts
@@ -25,9 +25,9 @@ type UseFormFieldA11yInput = {
    */
   controlId?: string;
   /**
-   * Whether the form field has a description (optional).
+   * Whether the form field has a help text (optional).
    */
-  hasDescription?: boolean;
+  hasHelpText?: boolean;
   /**
    * Whether the form field has a validation message (optional).
    */
@@ -73,7 +73,7 @@ type UseFormFieldA11yOutput = {
  * ```
  */
 export function useFormFieldA11y(input: UseFormFieldA11yInput = {}): UseFormFieldA11yOutput {
-  const { controlId, hasDescription, hasValidationMessage } = input;
+  const { controlId, hasHelpText, hasValidationMessage } = input;
 
   const defaultId = useId();
   const id = controlId ?? defaultId;
@@ -86,7 +86,7 @@ export function useFormFieldA11y(input: UseFormFieldA11yInput = {}): UseFormFiel
     describedBy.push(validationMessageId);
   }
 
-  if (hasDescription) {
+  if (hasHelpText) {
     describedBy.push(helpTextId);
   }
 

--- a/src/components/form/useFormFieldA11y.ts
+++ b/src/components/form/useFormFieldA11y.ts
@@ -44,9 +44,9 @@ type UseFormFieldA11yOutput = {
    */
   describedBy: string | undefined;
   /**
-   * The ID that should be used for the description.
+   * The ID that should be used for the help text.
    */
-  descriptionId: string;
+  helpTextId: string;
   /**
    * The ID that should be used for the label.
    */
@@ -66,7 +66,7 @@ type UseFormFieldA11yOutput = {
  * const {
  *   controlId,
  *   describedBy,
- *   descriptionId,
+ *   helpTextId,
  *   labelId,
  *   validationMessageId
  * } = useFormFieldA11y()
@@ -78,7 +78,7 @@ export function useFormFieldA11y(input: UseFormFieldA11yInput = {}): UseFormFiel
   const defaultId = useId();
   const id = controlId ?? defaultId;
   const describedBy: string[] = [];
-  const descriptionId = `${controlId}-description`;
+  const helpTextId = `${controlId}-help-text`;
   const labelId = `${controlId}-label`;
   const validationMessageId = `${controlId}-validation-message`;
 
@@ -87,13 +87,13 @@ export function useFormFieldA11y(input: UseFormFieldA11yInput = {}): UseFormFiel
   }
 
   if (hasDescription) {
-    describedBy.push(descriptionId);
+    describedBy.push(helpTextId);
   }
 
   return {
     controlId: id,
     describedBy: describedBy.length > 0 ? describedBy.join(' ') : undefined,
-    descriptionId,
+    helpTextId,
     labelId,
     validationMessageId,
   };

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -22,6 +22,7 @@ import styled from '@emotion/styled';
 import * as RadixPopover from '@radix-ui/react-popover';
 import { ReactElement, ReactNode, forwardRef, useContext } from 'react';
 import { isDefined } from '~common/helpers/types';
+import { TextNodeOptional } from '~types/utils';
 import { THEME_DATA_ATTRIBUTE, ThemeContext } from '~utils/theme';
 import { Heading, HeadingSize, Text, TextSize } from '../typography';
 
@@ -38,15 +39,15 @@ export enum PopoverSide {
   Left = 'left',
 }
 
-interface Props {
-  align?: PopoverAlign;
+export interface PopoverProps {
+  align?: `${PopoverAlign}`;
   children: ReactElement;
-  description?: ReactNode;
+  description?: TextNodeOptional;
   extraContent?: ReactNode;
   footer?: ReactNode; // Enforce Button, ButtonGroup or Link ?
   isOpen?: boolean;
-  side?: PopoverSide;
-  title: string;
+  side?: `${PopoverSide}`;
+  title?: TextNodeOptional;
 }
 
 /* This is the distance between the point of the arrow and the trigger */
@@ -71,7 +72,7 @@ const ARROW_PADDING = 16;
  *
  * Since the popovers are appended to the body, they are in the root Stacking Context. If other elements are also there, the z-index will determine which appears on top. By creating a new Stacking Context for your app, it ensures that z-indexed elements will stay within that context, while popovers will be painted on top, in the parent Stacking Context.
  */
-export const Popover = forwardRef<HTMLButtonElement, Props>((props, ref) => {
+export const Popover = forwardRef<HTMLButtonElement, PopoverProps>((props, ref) => {
   const { align, children, description, extraContent, footer, isOpen, side, title, ...radixProps } =
     props;
   const theme = useContext(ThemeContext);
@@ -89,9 +90,11 @@ export const Popover = forwardRef<HTMLButtonElement, Props>((props, ref) => {
           arrowPadding={ARROW_PADDING}
           side={side}
           sideOffset={POPOVER_OFFSET}>
-          <Heading as="h1" hasMarginBottom size={HeadingSize.Medium}>
-            {title}
-          </Heading>
+          {title && (
+            <Heading as="h1" hasMarginBottom={Boolean(description)} size={HeadingSize.Medium}>
+              {title}
+            </Heading>
+          )}
 
           {description && (
             <Text isSubdued size={TextSize.Small}>

--- a/src/components/popover/index.ts
+++ b/src/components/popover/index.ts
@@ -18,4 +18,4 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export { Popover, PopoverAlign, PopoverSide } from './Popover';
+export { Popover, PopoverAlign, PopoverSide, type PopoverProps } from './Popover';

--- a/src/components/radio-button-group/RadioButtonGroup.tsx
+++ b/src/components/radio-button-group/RadioButtonGroup.tsx
@@ -69,7 +69,7 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props
 
   const defaultId = `${useId()}radiogroup`;
 
-  const { controlId, describedBy, descriptionId, labelId, validationMessageId } = useFormFieldA11y({
+  const { controlId, describedBy, helpTextId, labelId, validationMessageId } = useFormFieldA11y({
     controlId: id ?? defaultId,
     hasDescription: Boolean(helpText),
     hasValidationMessage: Boolean(messageValid || messageInvalid),
@@ -78,8 +78,8 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props
   return (
     <FormField
       className={className}
-      description={helpText}
-      descriptionId={descriptionId}
+      helpText={helpText}
+      helpTextId={helpTextId}
       isDisabled={disabled}
       isRequired={required}
       label={label}

--- a/src/components/radio-button-group/RadioButtonGroup.tsx
+++ b/src/components/radio-button-group/RadioButtonGroup.tsx
@@ -26,13 +26,15 @@ import { PropsWithLabels } from '~types/utils';
 import {
   type ValidationProps,
   FormField,
+  FormFieldProps,
   FormFieldValidation,
-  FormFieldWidth,
 } from '../form/FormField';
 import { useFormFieldA11y } from '../form/useFormFieldA11y';
 import { HelperText, Label } from '../typography';
 
-interface Props extends ValidationProps {
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'width'>;
+
+interface Props extends ValidationProps, FormFieldPropsSubset {
   onChange?: (value: string) => void;
   options: RadioOption[];
 
@@ -44,7 +46,6 @@ interface Props extends ValidationProps {
   isDisabled?: boolean;
   isRequired?: boolean;
   value?: string;
-  width?: `${FormFieldWidth}`;
 }
 
 export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props>>((props, ref) => {
@@ -54,6 +55,7 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props
     ariaLabelledBy,
     className,
     helpText,
+    helpToggletip,
     id = 'radio-button-group',
     isDisabled: disabled,
     isRequired: required,
@@ -80,6 +82,7 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props
       className={className}
       helpText={helpText}
       helpTextId={helpTextId}
+      helpToggletip={helpToggletip}
       isDisabled={disabled}
       isRequired={required}
       label={label}

--- a/src/components/radio-button-group/RadioButtonGroup.tsx
+++ b/src/components/radio-button-group/RadioButtonGroup.tsx
@@ -32,7 +32,7 @@ import {
 import { useFormFieldA11y } from '../form/useFormFieldA11y';
 import { HelperText, Label } from '../typography';
 
-type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'width'>;
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletipProps' | 'width'>;
 
 interface Props extends ValidationProps, FormFieldPropsSubset {
   onChange?: (value: string) => void;
@@ -55,7 +55,7 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props
     ariaLabelledBy,
     className,
     helpText,
-    helpToggletip,
+    helpToggletipProps,
     id = 'radio-button-group',
     isDisabled: disabled,
     isRequired: required,
@@ -73,7 +73,7 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props
 
   const { controlId, describedBy, helpTextId, labelId, validationMessageId } = useFormFieldA11y({
     controlId: id ?? defaultId,
-    hasDescription: Boolean(helpText),
+    hasHelpText: Boolean(helpText),
     hasValidationMessage: Boolean(messageValid || messageInvalid),
   });
 
@@ -82,7 +82,7 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Props
       className={className}
       helpText={helpText}
       helpTextId={helpTextId}
-      helpToggletip={helpToggletip}
+      helpToggletipProps={helpToggletipProps}
       isDisabled={disabled}
       isRequired={required}
       label={label}

--- a/src/components/select/SelectCommons.tsx
+++ b/src/components/select/SelectCommons.tsx
@@ -103,7 +103,7 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
     const isClearable = !isNotClearable && !isRequired && !isDisabled;
     const defaultId = `${useId()}select`;
 
-    const { controlId, describedBy, descriptionId, validationMessageId } = useFormFieldA11y({
+    const { controlId, describedBy, helpTextId, validationMessageId } = useFormFieldA11y({
       controlId: id ?? defaultId,
       hasDescription: Boolean(helpText),
       hasValidationMessage: Boolean(messageValid || messageInvalid),
@@ -127,8 +127,8 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
     return (
       <FormField
         controlId={controlId}
-        description={helpText}
-        descriptionId={descriptionId}
+        helpText={helpText}
+        helpTextId={helpTextId}
         isDisabled={isDisabled}
         isRequired={isRequired}
         label={label}

--- a/src/components/select/SelectCommons.tsx
+++ b/src/components/select/SelectCommons.tsx
@@ -39,7 +39,7 @@ import { OptionComponent, useSelectOptionFunction } from './SelectItemCommons';
 import { SelectData, SelectHighlight, SelectOption, SelectOptionType } from './SelectTypes';
 import { SelectFilterFunction, useSelectOptionFilter } from './useSelectOptionFilter';
 
-type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'width'>;
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletipProps' | 'width'>;
 
 export interface SelectBaseProps extends ValidationProps, FormFieldPropsSubset {
   className?: string;
@@ -75,7 +75,7 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
       filter,
       hasDropdownAutoWidth = false,
       helpText,
-      helpToggletip,
+      helpToggletipProps,
       highlight = SelectHighlight.Default,
       id,
       isDisabled = false,
@@ -107,7 +107,7 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
 
     const { controlId, describedBy, helpTextId, validationMessageId } = useFormFieldA11y({
       controlId: id ?? defaultId,
-      hasDescription: Boolean(helpText),
+      hasHelpText: Boolean(helpText),
       hasValidationMessage: Boolean(messageValid || messageInvalid),
     });
 
@@ -131,7 +131,7 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
         controlId={controlId}
         helpText={helpText}
         helpTextId={helpTextId}
-        helpToggletip={helpToggletip}
+        helpToggletipProps={helpToggletipProps}
         isDisabled={isDisabled}
         isRequired={isRequired}
         label={label}

--- a/src/components/select/SelectCommons.tsx
+++ b/src/components/select/SelectCommons.tsx
@@ -31,15 +31,17 @@ import { PortalContext } from '../../common/components/PortalContext';
 import {
   type ValidationProps,
   FormField,
+  FormFieldProps,
   FormFieldValidation,
-  FormFieldWidth,
 } from '../form/FormField';
 import { useFormFieldA11y } from '../form/useFormFieldA11y';
 import { OptionComponent, useSelectOptionFunction } from './SelectItemCommons';
 import { SelectData, SelectHighlight, SelectOption, SelectOptionType } from './SelectTypes';
 import { SelectFilterFunction, useSelectOptionFilter } from './useSelectOptionFilter';
 
-export interface SelectBaseProps extends ValidationProps {
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'width'>;
+
+export interface SelectBaseProps extends ValidationProps, FormFieldPropsSubset {
   className?: string;
   data: SelectData;
   defaultValue?: MantineSelectProps['defaultValue'];
@@ -62,7 +64,6 @@ export interface SelectBaseProps extends ValidationProps {
   placeholder?: MantineSelectProps['placeholder'];
   value: MantineSelectProps['value'];
   valueIcon?: MantineSelectProps['leftSection'];
-  width?: `${FormFieldWidth}`;
 }
 
 export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBaseProps>>(
@@ -74,6 +75,7 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
       filter,
       hasDropdownAutoWidth = false,
       helpText,
+      helpToggletip,
       highlight = SelectHighlight.Default,
       id,
       isDisabled = false,
@@ -129,6 +131,7 @@ export const SelectBase = forwardRef<HTMLInputElement, PropsWithLabels<SelectBas
         controlId={controlId}
         helpText={helpText}
         helpTextId={helpTextId}
+        helpToggletip={helpToggletip}
         isDisabled={isDisabled}
         isRequired={isRequired}
         label={label}

--- a/src/components/text-area/TextArea.tsx
+++ b/src/components/text-area/TextArea.tsx
@@ -49,6 +49,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
     ariaLabel,
     ariaLabelledBy,
     helpText,
+    helpToggletip,
     id,
     isDisabled = false,
     isResizable = false,
@@ -75,6 +76,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
       controlId={controlId}
       helpText={helpText}
       helpTextId={helpTextId}
+      helpToggletip={helpToggletip}
       isDisabled={isDisabled}
       isRequired={isRequired}
       label={label}

--- a/src/components/text-area/TextArea.tsx
+++ b/src/components/text-area/TextArea.tsx
@@ -49,7 +49,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
     ariaLabel,
     ariaLabelledBy,
     helpText,
-    helpToggletip,
+    helpToggletipProps,
     id,
     isDisabled = false,
     isResizable = false,
@@ -67,7 +67,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
 
   const { controlId, describedBy, helpTextId, validationMessageId } = useFormFieldA11y({
     controlId: id ?? defaultId,
-    hasDescription: Boolean(helpText),
+    hasHelpText: Boolean(helpText),
     hasValidationMessage: Boolean(messageValid || messageInvalid),
   });
 
@@ -76,7 +76,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
       controlId={controlId}
       helpText={helpText}
       helpTextId={helpTextId}
-      helpToggletip={helpToggletip}
+      helpToggletipProps={helpToggletipProps}
       isDisabled={isDisabled}
       isRequired={isRequired}
       label={label}

--- a/src/components/text-area/TextArea.tsx
+++ b/src/components/text-area/TextArea.tsx
@@ -64,7 +64,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
 
   const defaultId = `${useId()}textarea`;
 
-  const { controlId, describedBy, descriptionId, validationMessageId } = useFormFieldA11y({
+  const { controlId, describedBy, helpTextId, validationMessageId } = useFormFieldA11y({
     controlId: id ?? defaultId,
     hasDescription: Boolean(helpText),
     hasValidationMessage: Boolean(messageValid || messageInvalid),
@@ -73,8 +73,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, r
   return (
     <FormField
       controlId={controlId}
-      description={helpText}
-      descriptionId={descriptionId}
+      helpText={helpText}
+      helpTextId={helpTextId}
       isDisabled={isDisabled}
       isRequired={isRequired}
       label={label}

--- a/src/components/text-input/TextInput.tsx
+++ b/src/components/text-input/TextInput.tsx
@@ -61,7 +61,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
     ariaLabel,
     ariaLabelledBy,
     helpText,
-    helpToggletip,
+    helpToggletipProps,
     id,
     isDisabled = false,
     isRequired = false,
@@ -80,7 +80,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
 
   const { controlId, describedBy, helpTextId, validationMessageId } = useFormFieldA11y({
     controlId: id ?? defaultId,
-    hasDescription: Boolean(helpText),
+    hasHelpText: Boolean(helpText),
     hasValidationMessage: Boolean(messageValid || messageInvalid),
   });
 
@@ -89,7 +89,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
       controlId={controlId}
       helpText={helpText}
       helpTextId={helpTextId}
-      helpToggletip={helpToggletip}
+      helpToggletipProps={helpToggletipProps}
       isDisabled={isDisabled}
       isRequired={isRequired}
       label={label}

--- a/src/components/text-input/TextInput.tsx
+++ b/src/components/text-input/TextInput.tsx
@@ -61,6 +61,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
     ariaLabel,
     ariaLabelledBy,
     helpText,
+    helpToggletip,
     id,
     isDisabled = false,
     isRequired = false,
@@ -88,6 +89,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
       controlId={controlId}
       helpText={helpText}
       helpTextId={helpTextId}
+      helpToggletip={helpToggletip}
       isDisabled={isDisabled}
       isRequired={isRequired}
       label={label}

--- a/src/components/text-input/TextInput.tsx
+++ b/src/components/text-input/TextInput.tsx
@@ -77,7 +77,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
 
   const defaultId = `${useId()}textinput`;
 
-  const { controlId, describedBy, descriptionId, validationMessageId } = useFormFieldA11y({
+  const { controlId, describedBy, helpTextId, validationMessageId } = useFormFieldA11y({
     controlId: id ?? defaultId,
     hasDescription: Boolean(helpText),
     hasValidationMessage: Boolean(messageValid || messageInvalid),
@@ -86,8 +86,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>((props, re
   return (
     <FormField
       controlId={controlId}
-      description={helpText}
-      descriptionId={descriptionId}
+      helpText={helpText}
+      helpTextId={helpTextId}
       isDisabled={isDisabled}
       isRequired={isRequired}
       label={label}

--- a/src/components/text-input/TextInputBase.tsx
+++ b/src/components/text-input/TextInputBase.tsx
@@ -19,7 +19,7 @@
  */
 import styled from '@emotion/styled';
 import { InputHTMLAttributes } from 'react';
-import { type ValidationProps, FormFieldWidth } from '../form/FormField';
+import { type ValidationProps, FormFieldProps } from '../form/FormField';
 
 type InputEventAttributesSubset =
   | 'onFocus'
@@ -36,13 +36,13 @@ type InputEventAttributesSubset =
 
 export type InputEventProps<T> = Pick<InputHTMLAttributes<T>, InputEventAttributesSubset>;
 
-export interface InputProps extends ValidationProps {
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'isRequired' | 'width'>;
+
+export interface InputProps extends ValidationProps, FormFieldPropsSubset {
   className?: string;
   isDisabled?: boolean;
-  isRequired?: boolean;
   placeholder?: string;
   value?: string | number;
-  width?: `${FormFieldWidth}`;
 }
 
 export const InputStyled = styled.input`

--- a/src/components/text-input/TextInputBase.tsx
+++ b/src/components/text-input/TextInputBase.tsx
@@ -36,7 +36,7 @@ type InputEventAttributesSubset =
 
 export type InputEventProps<T> = Pick<InputHTMLAttributes<T>, InputEventAttributesSubset>;
 
-type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletip' | 'isRequired' | 'width'>;
+type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletipProps' | 'isRequired' | 'width'>;
 
 export interface InputProps extends ValidationProps, FormFieldPropsSubset {
   className?: string;

--- a/src/components/toggle-tip/ToggleTip.tsx
+++ b/src/components/toggle-tip/ToggleTip.tsx
@@ -19,42 +19,44 @@
  */
 
 import styled from '@emotion/styled';
-import { ComponentProps, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { useIntl } from 'react-intl';
 import { ButtonIcon, ButtonVariety } from '../buttons';
 import { IconInfo } from '../icons';
-import { Popover } from '../popover';
+import { Popover, PopoverProps } from '../popover';
 
-type PopoverProps = Omit<ComponentProps<typeof Popover>, 'children'>;
+type PopoverPropsSubset = Omit<PopoverProps, 'children'>;
 
-interface Props extends PopoverProps {
+export interface ToggleTipProps extends PopoverPropsSubset {
   ariaLabel?: string;
   className?: string;
 }
 
-export const ToggleTip = forwardRef<HTMLButtonElement, Props>((props: Props, ref) => {
-  const { ariaLabel, className, ...popoverProps } = props;
+export const ToggleTip = forwardRef<HTMLButtonElement, ToggleTipProps>(
+  (props: ToggleTipProps, ref) => {
+    const { ariaLabel, className, ...popoverProps } = props;
 
-  const intl = useIntl();
+    const intl = useIntl();
 
-  const defaultAriaLabel = intl.formatMessage({
-    id: 'toggletip.help',
-    defaultMessage: 'More information',
-    description: 'aria-label text and tooltip for the ToggleTip',
-  });
+    const defaultAriaLabel = intl.formatMessage({
+      id: 'toggletip.help',
+      defaultMessage: 'More information',
+      description: 'aria-label text and tooltip for the ToggleTip',
+    });
 
-  return (
-    <Popover {...popoverProps}>
-      <ToggleTipButtonIcon
-        Icon={IconInfo}
-        ariaLabel={ariaLabel ?? defaultAriaLabel}
-        className={className}
-        ref={ref}
-        variety={ButtonVariety.DefaultGhost}
-      />
-    </Popover>
-  );
-});
+    return (
+      <Popover {...popoverProps}>
+        <ToggleTipButtonIcon
+          Icon={IconInfo}
+          ariaLabel={ariaLabel ?? defaultAriaLabel}
+          className={className}
+          ref={ref}
+          variety={ButtonVariety.DefaultGhost}
+        />
+      </Popover>
+    );
+  },
+);
 
 const ToggleTipButtonIcon = styled(ButtonIcon)`
   line-height: var(--echoes-line-height-10);

--- a/src/components/toggle-tip/index.ts
+++ b/src/components/toggle-tip/index.ts
@@ -18,4 +18,4 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export { ToggleTip } from './ToggleTip';
+export { ToggleTip, type ToggleTipProps } from './ToggleTip';

--- a/stories/FormField-stories.tsx
+++ b/stories/FormField-stories.tsx
@@ -28,6 +28,15 @@ const meta: Meta<FormField> = {
   component: FormField,
   title: 'Internal/FormField',
   argTypes: {
+    helpToggletip: {
+      mapping: {
+        'with-help-toggletip': {
+          description: 'This toggletip will be displayed next to the help text.',
+        },
+        none: undefined,
+      },
+      options: ['with-help-toggletip', 'none'],
+    },
     validation: {
       control: { type: 'select' },
       table: {

--- a/stories/FormField-stories.tsx
+++ b/stories/FormField-stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<FormField> = {
   component: FormField,
   title: 'Internal/FormField',
   argTypes: {
-    helpToggletip: {
+    helpToggletipProps: {
       mapping: {
         'with-help-toggletip': {
           description: 'This toggletip will be displayed next to the help text.',

--- a/stories/FormField-stories.tsx
+++ b/stories/FormField-stories.tsx
@@ -40,7 +40,7 @@ const meta: Meta<FormField> = {
         defaultValue: { summary: FormFieldWidth.Full },
       },
     },
-    ...toTextControlArgTypes('label', 'description', 'messageInvalid', 'messageValid'),
+    ...toTextControlArgTypes('label', 'helpText', 'messageInvalid', 'messageValid'),
   },
   parameters: {
     docs: {
@@ -56,7 +56,7 @@ type Story = StoryObj<FormField>;
 export const Default: Story = {
   args: {
     controlId: 'input-1',
-    description: 'Your password must contain at least 8 characters',
+    helpText: 'Your password must contain at least 8 characters',
     isDisabled: false,
     isRequired: false,
     label: 'Password',
@@ -128,7 +128,7 @@ export const Valid: Story = {
 export const Medium: Story = {
   args: {
     controlId: 'input-6',
-    description: 'Your password must contain at least 8 characters',
+    helpText: 'Your password must contain at least 8 characters',
     label: 'Password',
     width: FormFieldWidth.Medium,
   },

--- a/stories/TextInput-stories.tsx
+++ b/stories/TextInput-stories.tsx
@@ -56,6 +56,9 @@ export const Basic: Story = {
 export const AsFormField: Story = {
   args: {
     helpText: `I'm a text to help you fill me correctly!`,
+    helpToggletip: {
+      description: `I'm a help toggletip, here to help you better understand the form field.`,
+    },
     isRequired: true,
     label: `I'm a label`,
     placeholder: 'I am a placeholder',

--- a/stories/TextInput-stories.tsx
+++ b/stories/TextInput-stories.tsx
@@ -56,7 +56,7 @@ export const Basic: Story = {
 export const AsFormField: Story = {
   args: {
     helpText: `I'm a text to help you fill me correctly!`,
-    helpToggletip: {
+    helpToggletipProps: {
       description: `I'm a help toggletip, here to help you better understand the form field.`,
     },
     isRequired: true,

--- a/stories/helpers/arg-types.tsx
+++ b/stories/helpers/arg-types.tsx
@@ -56,7 +56,7 @@ export function toDisabledControlArgType<TArgs = Args>(...args: (keyof TArgs)[])
 
 export const formFieldsArgTypes: ArgTypes<PropsWithLabels<InputProps>> = {
   ...toTextControlArgTypes('label', 'helpText', 'messageInvalid', 'messageValid', 'value'),
-  helpToggletip: {
+  helpToggletipProps: {
     mapping: {
       'with-help-toggletip': {
         description: 'This toggletip will be displayed next to the help text.',

--- a/stories/helpers/arg-types.tsx
+++ b/stories/helpers/arg-types.tsx
@@ -56,6 +56,15 @@ export function toDisabledControlArgType<TArgs = Args>(...args: (keyof TArgs)[])
 
 export const formFieldsArgTypes: ArgTypes<PropsWithLabels<InputProps>> = {
   ...toTextControlArgTypes('label', 'helpText', 'messageInvalid', 'messageValid', 'value'),
+  helpToggletip: {
+    mapping: {
+      'with-help-toggletip': {
+        description: 'This toggletip will be displayed next to the help text.',
+      },
+      none: undefined,
+    },
+    options: ['with-help-toggletip', 'none'],
+  },
   validation: {
     control: { type: 'select' },
     table: {


### PR DESCRIPTION
[ECHOES-583](https://sonarsource.atlassian.net/browse/ECHOES-583)

Part of [ECHOES-455](https://sonarsource.atlassian.net/browse/ECHOES-455)

Fixes:

![image](https://github.com/user-attachments/assets/0b2a8e08-d884-46b8-82dc-8915320aab39)


[ECHOES-455]: https://sonarsource.atlassian.net/browse/ECHOES-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ECHOES-583]: https://sonarsource.atlassian.net/browse/ECHOES-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ