### PR TITLE
ECHOES-587 Allow overriding the submit button variety of ModalForm

### DIFF
--- a/src/components/modals/ModalForm.tsx
+++ b/src/components/modals/ModalForm.tsx
@@ -61,6 +61,10 @@ export interface ModalFormProps extends FormRootPropsSubset, ModalPropsSubset {
    * Allows to override the default text of the submit button.
    */
   submitButtonLabel?: TextNodeOptional;
+  /**
+   * Allows to override the default variety of the submit button.
+   */
+  submitButtonVariety?: `${ButtonVariety}`;
 }
 
 /**
@@ -105,6 +109,7 @@ export const ModalForm = forwardRef<HTMLDivElement, ModalFormProps>((props, ref)
     secondaryButtonLabel,
     shouldUseBrowserValidation,
     submitButtonLabel,
+    submitButtonVariety = ButtonVariety.Primary,
     target,
     ...modalProps
   } = props;
@@ -159,7 +164,7 @@ export const ModalForm = forwardRef<HTMLDivElement, ModalFormProps>((props, ref)
           isDisabled={isSubmitting || isSubmitDisabled}
           isLoading={isSubmitting}
           type="submit"
-          variety={ButtonVariety.Primary}>
+          variety={submitButtonVariety}>
           {submitButtonLabel ?? (
             <FormattedMessage
               defaultMessage="Submit"


### PR DESCRIPTION
[ECHOES-587](https://sonarsource.atlassian.net/browse/ECHOES-587)

I migrated the confirmation dialogs in the organization settings to use the ModalForm component but they use the `Danger` variety for the submit button. I thought it made sense to allow the variety of the submit button to be overridden instead of ejecting out of ModalForm.

Current Dialog

![image](https://github.com/user-attachments/assets/79628fb2-a034-4890-a603-c28918457271)

With ModalForm

![image](https://github.com/user-attachments/assets/303e7ebb-41cd-427a-88a4-5c02fa704d50)


[ECHOES-587]: https://sonarsource.atlassian.net/browse/ECHOES-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ