### PR TITLE
ECHOES-550 Fix issues with GlobalNavigation

### DIFF
--- a/src/components/global-navigation/GlobalNavigationDropdownItem.tsx
+++ b/src/components/global-navigation/GlobalNavigationDropdownItem.tsx
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import * as radixNavigationMenu from '@radix-ui/react-navigation-menu';
 import { Children, forwardRef, isValidElement, ReactNode, useMemo } from 'react';
 import { matchPath, useLocation } from 'react-router-dom';
 import { isDefined } from '~common/helpers/types';
@@ -67,11 +68,13 @@ export const GlobalNavigationDropdownItem = forwardRef<
     }, [pathname, dropdownMenuProps.items]);
 
     return (
-      <DropdownMenu {...dropdownMenuProps}>
-        <WrappedTrigger active={active} className={className} ref={ref}>
-          {children}
-        </WrappedTrigger>
-      </DropdownMenu>
+      <radixNavigationMenu.Item>
+        <DropdownMenu {...dropdownMenuProps}>
+          <WrappedTrigger active={active} className={className} ref={ref}>
+            {children}
+          </WrappedTrigger>
+        </DropdownMenu>
+      </radixNavigationMenu.Item>
     );
   },
 );

--- a/src/components/global-navigation/GlobalNavigationHome.tsx
+++ b/src/components/global-navigation/GlobalNavigationHome.tsx
@@ -21,16 +21,18 @@
 import styled from '@emotion/styled';
 import { forwardRef } from 'react';
 import { useIntl } from 'react-intl';
+import { LinkProps } from 'react-router-dom';
 import { LinkStandalone } from '../links';
 
 export interface GlobalNavigationHomeProps {
   children: React.ReactNode;
   className?: string;
   ariaLabel?: string;
+  reloadDocument?: LinkProps['reloadDocument'];
 }
 
 export const GlobalNavigationHome = forwardRef<HTMLDivElement, GlobalNavigationHomeProps>(
-  ({ children, ariaLabel, ...rest }: Readonly<GlobalNavigationHomeProps>, ref) => {
+  ({ children, ariaLabel, reloadDocument, ...rest }: Readonly<GlobalNavigationHomeProps>, ref) => {
     const intl = useIntl();
 
     const defaultAriaLabel = intl.formatMessage({
@@ -41,7 +43,10 @@ export const GlobalNavigationHome = forwardRef<HTMLDivElement, GlobalNavigationH
 
     return (
       <HomeContainer ref={ref} {...rest}>
-        <StyledLinkStandalone aria-label={ariaLabel ?? defaultAriaLabel} to="/">
+        <StyledLinkStandalone
+          aria-label={ariaLabel ?? defaultAriaLabel}
+          reloadDocument={reloadDocument}
+          to="/">
           <LogoContainer>{children}</LogoContainer>
         </StyledLinkStandalone>
       </HomeContainer>

--- a/src/components/global-navigation/GlobalNavigationItem.tsx
+++ b/src/components/global-navigation/GlobalNavigationItem.tsx
@@ -25,23 +25,26 @@ import { isDefined } from '~common/helpers/types';
 import { LinkBaseStyled } from '../links/LinkBaseStyled';
 import { globalNavigationItemStyle, StyledWrapper } from './GlobalNavigationItemStyles';
 
-export interface GlobalNavigationItemProps extends RouterLinkProps {
+export interface GlobalNavigationItemProps {
   children: ReactNode;
   className?: string;
+  to: RouterLinkProps['to'];
 }
 
 export const GlobalNavigationItem = forwardRef<HTMLAnchorElement, GlobalNavigationItemProps>(
-  ({ children, ...linkProps }: Readonly<GlobalNavigationItemProps>, ref) => {
-    const resolved = useResolvedPath(linkProps.to);
+  ({ children, className, to, ...otherProps }: Readonly<GlobalNavigationItemProps>, ref) => {
+    const resolved = useResolvedPath(to);
     const match = useMatch(resolved.pathname);
     const active = isDefined(match);
 
     return (
-      <radixNavigationMenu.Link active={active} asChild>
-        <WrappedLink active={active} ref={ref} {...linkProps}>
-          {children}
-        </WrappedLink>
-      </radixNavigationMenu.Link>
+      <radixNavigationMenu.Item>
+        <radixNavigationMenu.Link active={active} asChild>
+          <WrappedLink active={active} ref={ref} to={to} {...otherProps}>
+            {children}
+          </WrappedLink>
+        </radixNavigationMenu.Link>
+      </radixNavigationMenu.Item>
     );
   },
 );

--- a/src/components/global-navigation/GlobalNavigationItemsContainer.tsx
+++ b/src/components/global-navigation/GlobalNavigationItemsContainer.tsx
@@ -20,7 +20,7 @@
 
 import styled from '@emotion/styled';
 import * as radixNavigationMenu from '@radix-ui/react-navigation-menu';
-import { Children, PropsWithChildren, forwardRef } from 'react';
+import { PropsWithChildren, forwardRef } from 'react';
 
 export interface GlobalNavigationItemProps
   extends PropsWithChildren<radixNavigationMenu.NavigationMenuProps> {
@@ -31,17 +31,10 @@ export const GlobalNavigationItemsContainer = forwardRef<
   HTMLUListElement,
   GlobalNavigationItemProps
 >(({ children, className, ...radixProps }: Readonly<GlobalNavigationItemProps>, ref) => {
-  /*
-   * We need to wrap each child in a NavMenu Item to allow Radix to manage it
-   */
-  const wrappedChildren = Children.map(children, (child) => {
-    return <StyledNavigationMenuItem>{child}</StyledNavigationMenuItem>;
-  });
-
   return (
     <radixNavigationMenu.Root>
       <StyledNavigationMenuRoot ref={ref} {...radixProps}>
-        {wrappedChildren}
+        {children}
       </StyledNavigationMenuRoot>
     </radixNavigationMenu.Root>
   );
@@ -59,6 +52,3 @@ const StyledNavigationMenuRoot = styled(radixNavigationMenu.List)`
   margin: 0;
 `;
 StyledNavigationMenuRoot.displayName = 'StyledNavigationMenuRoot';
-
-const StyledNavigationMenuItem = styled(radixNavigationMenu.Item)``;
-StyledNavigationMenuItem.displayName = 'StyledNavigationMenuItem';

--- a/stories/GlobalNavigation-stories.tsx
+++ b/stories/GlobalNavigation-stories.tsx
@@ -60,8 +60,10 @@ export const Default: Story = {
           <GlobalNavigation.Home>{children}</GlobalNavigation.Home>
 
           <GlobalNavigation.ItemsContainer>
-            <GlobalNavigation.Item to="/">Home</GlobalNavigation.Item>
-            <GlobalNavigation.Item to="/qp">Quality Profiles</GlobalNavigation.Item>
+            <>
+              <GlobalNavigation.Item to="/">Home</GlobalNavigation.Item>
+              <GlobalNavigation.Item to="/qp">Quality Profiles</GlobalNavigation.Item>
+            </>
             <GlobalNavigation.Item to="/rules">Rules</GlobalNavigation.Item>
             <GlobalNavigation.DropdownItem
               items={


### PR DESCRIPTION
- Removes the children wrapping logic in the Item Container and wraps the Item and DownloadItem directly
  - This allows fragments around Items in the products
  - Code is simpler and not as brittle. Also no more "magic"
- Add `reloadDocument` prop to Home


Based on the WIP [integration in SQC](https://github.com/SonarSource/sonarcloud-webapp/tree/jay/navbar-migration-sqc)