### PR TITLE
ECHOES-633 ModalForm shouldn't throw on promise onSubmit reject

### DIFF
--- a/src/components/modals/ModalForm.tsx
+++ b/src/components/modals/ModalForm.tsx
@@ -134,7 +134,12 @@ export const ModalForm = forwardRef<HTMLDivElement, ModalFormProps>((props, ref)
     (event: FormEvent<HTMLFormElement>) => {
       const submitResult = onSubmit?.(event);
       if (submitResult instanceof Promise) {
-        return submitResult.then(() => setIsOpen(false));
+        return submitResult.then(
+          () => setIsOpen(false),
+          () => {
+            // Do nothing on reject
+          },
+        );
       }
       setIsOpen(false);
     },

--- a/src/components/modals/__tests__/ModalForm-test.tsx
+++ b/src/components/modals/__tests__/ModalForm-test.tsx
@@ -68,6 +68,25 @@ it('should correctly handle submitting a promise', async () => {
   await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
 });
 
+it('should correctly handle submitting a rejected promise', async () => {
+  const onSubmit = jest.fn().mockImplementation((e) => {
+    e.preventDefault();
+    return new Promise((_resolve, reject) => {
+      reject(new Error());
+    });
+  });
+  const { user } = renderModalForm({ onSubmit });
+
+  await user.click(screen.getByRole('button', { name: 'Toggle' }));
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: 'Submit' }));
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(onSubmit).toHaveBeenCalled();
+
+  expect(screen.queryByRole('dialog')).toBeVisible();
+});
+
 it('should correctly handle overriding buttons text', async () => {
   const { user } = renderModalForm({ submitButtonLabel: 'Save', secondaryButtonLabel: 'Reset' });
 


### PR DESCRIPTION
[ECHOES-633](https://sonarsource.atlassian.net/browse/ECHOES-633)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[ECHOES-633]: https://sonarsource.atlassian.net/browse/ECHOES-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ