### PR TITLE
ECHOES-684 Add optional icon prop to Badge

### DIFF
--- a/src/components/badges/Badge.tsx
+++ b/src/components/badges/Badge.tsx
@@ -20,6 +20,8 @@
 
 import styled from '@emotion/styled';
 import { forwardRef, PropsWithChildren, useMemo } from 'react';
+import { isDefined } from '~common/helpers/types';
+import { IconFilledProps } from '../icons/IconWrapper';
 
 export enum BadgeSize {
   Small = 'small',
@@ -36,18 +38,24 @@ export enum BadgeVariety {
 }
 
 export interface BadgeProps extends PropsWithChildren {
+  IconLeft?: React.ForwardRefExoticComponent<
+    IconFilledProps & React.RefAttributes<HTMLSpanElement>
+  >;
   ariaLabel?: string;
   className?: string;
   isHighContrast?: boolean;
+  isIconFilled?: boolean;
   size?: `${BadgeSize}`;
   variety: `${BadgeVariety}`;
 }
 
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
   const {
+    IconLeft,
     ariaLabel,
     children,
     isHighContrast = false,
+    isIconFilled = false,
     size = BadgeSize.Small,
     variety,
     ...otherProps
@@ -67,6 +75,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
         [isHighContrast, size, variety],
       )}
       ref={ref}>
+      {isDefined(IconLeft) && <IconLeft isFilled={isIconFilled} />}
       {children}
     </StyledBadge>
   );
@@ -75,6 +84,10 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
 Badge.displayName = 'Badge';
 
 const StyledBadge = styled.span`
+  display: flex;
+  flex-direction: row;
+  gap: var(--echoes-dimension-space-50);
+
   box-sizing: border-box;
 
   color: var(--badge-color);

--- a/src/components/badges/__tests__/Badge-test.tsx
+++ b/src/components/badges/__tests__/Badge-test.tsx
@@ -19,6 +19,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import { IconStar } from '../../icons';
 import { Badge } from '../Badge';
 
 describe('Badge', () => {
@@ -35,9 +36,11 @@ describe('Badge', () => {
   it('accepts custom ariaLabel and className props', () => {
     render(
       <Badge
+        IconLeft={IconStar}
         ariaLabel="custom label"
         className="custom class"
         isHighContrast
+        isIconFilled
         size="medium"
         variety="danger">
         watch out!

--- a/stories/badges/Badge-stories.tsx
+++ b/stories/badges/Badge-stories.tsx
@@ -20,13 +20,23 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 import { Badge } from '../../src';
+import { iconsComponentsArgType } from '../helpers/arg-types';
 import { BasicWrapper } from '../helpers/BasicWrapper';
+
+const { mapping, options = [] } = iconsComponentsArgType;
 
 const meta: Meta<typeof Badge> = {
   component: Badge,
 
   parameters: {
     controls: { exclude: ['className'] },
+  },
+
+  argTypes: {
+    IconLeft: {
+      mapping: { ...mapping, none: undefined },
+      options: [...options, 'none'],
+    },
   },
 
   title: 'Echoes/Badges/Badge',


### PR DESCRIPTION
[ECHOES-684](https://sonarsource.atlassian.net/browse/ECHOES-684)

I missed this in the design, found it in the docs :sweat_smile: 

[ECHOES-684]: https://sonarsource.atlassian.net/browse/ECHOES-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ