### PR TITLE
ECHOES-685 Fix BadgeCounter size

### DIFF
--- a/src/components/badges/BadgeCounter.tsx
+++ b/src/components/badges/BadgeCounter.tsx
@@ -40,6 +40,7 @@ BadgeCounter.displayName = 'BadgeCounter';
 
 const BadgeCounterStyled = styled.span`
   display: inline-block;
+  height: var(--echoes-line-height-10);
 
   border-radius: var(--echoes-border-radius-full);
   padding: var(--echoes-dimension-space-0) var(--echoes-dimension-space-50);


### PR DESCRIPTION
It seems the badge doesn't adapt well to all situations. Enforcing the height is necessary:

![image](https://github.com/user-attachments/assets/4bd80780-2bd9-46e4-b21c-7f9c454794d7)
