### PR TITLE
ECHOES-806 Fix small alignment issue with min length message in SearchInput

### DIFF
--- a/src/components/search-input/SearchInput.tsx
+++ b/src/components/search-input/SearchInput.tsx
@@ -311,5 +311,6 @@ const MinLengthMessage = styled(Text)`
   right: calc(var(--echoes-dimension-space-150) + var(--echoes-dimension-width-300));
   text-align: right;
   pointer-events: none;
+  margin-top: 1px;
 `;
 MinLengthMessage.displayName = 'MinLengthMessage';


### PR DESCRIPTION
[ECHOES-806](https://sonarsource.atlassian.net/browse/ECHOES-806)

Not super obvious but when switching for the too long message that displayed in the placeholder and the one that's on the right we can see a small move up of the text, adding this top margin aligns it perfectly.
No need to do a patch release for that.