### PR TITLE
ECHOES-807 Update badge severity to better communicate severity level

### DIFF
--- a/i18n/keys.json
+++ b/i18n/keys.json
@@ -114,6 +114,26 @@
     "defaultMessage": "Clear select field",
     "description": "Screen reader-only text to indicate that the select field can be cleared with a button"
   },
+  "severity_impact.BLOCKER": {
+    "defaultMessage": "Blocker",
+    "description": "Label for blocker severity level"
+  },
+  "severity_impact.HIGH": {
+    "defaultMessage": "High",
+    "description": "Label for high severity level"
+  },
+  "severity_impact.INFO": {
+    "defaultMessage": "Info",
+    "description": "Label for info severity level"
+  },
+  "severity_impact.LOW": {
+    "defaultMessage": "Low",
+    "description": "Label for low severity level"
+  },
+  "severity_impact.MEDIUM": {
+    "defaultMessage": "Medium",
+    "description": "Label for medium severity level"
+  },
   "spotlight.close": {
     "defaultMessage": "Close",
     "description": "The label for the Close button on a Spotlight"

--- a/src/components/badges/BadgeSeverity.tsx
+++ b/src/components/badges/BadgeSeverity.tsx
@@ -64,6 +64,11 @@ export interface BadgeSeverityProps extends InheritedButtonProps {
   ariaLabel: string;
 
   /**
+   * Indicates that this badge opens a dropdown menu.
+   */
+  hasDropdownIndicator?: boolean;
+
+  /**
    * Indicates whether the badge is in a loading state, which will replace the button's icon with the spinner
    */
   isLoading?: boolean;
@@ -86,6 +91,7 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
     ariaLabel,
     className,
     hasAutoFocus = false,
+    hasDropdownIndicator = false,
     isDisabled = false,
     isIconFilled = false,
     isLoading = false,
@@ -154,7 +160,7 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
           autoFocus={hasAutoFocus}
           css={useMemo(
             () => ({
-              '--button-padding': 'var(--echoes-dimension-space-50)',
+              '--button-padding': 'var(--echoes-dimension-space-75)',
               '--button-height': 'auto',
               '--button-width': 'auto',
 
@@ -172,15 +178,14 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
           ref={ref}
           type="button">
           <StyledSeverityContent>
-            {isDefined(isLoading) ? (
-              <SpinnerOverrideColor isLoading={isLoading}>
-                <SeverityIcon />
-              </SpinnerOverrideColor>
-            ) : (
-              <SeverityIcon />
-            )}
+            {isLoading && <SpinnerOverrideColor isLoading={isLoading} />}
+            {!isLoading && <SeverityIcon />}
             <StyledSeverityText>{severityLabel}</StyledSeverityText>
-            {!isDisabled && <IconChevronDown />}
+            {!isDisabled && hasDropdownIndicator && (
+              <StyledDropdownIndicator>
+                <IconChevronDown />
+              </StyledDropdownIndicator>
+            )}
           </StyledSeverityContent>
         </StyledButtonIconStyled>
       </Tooltip>
@@ -218,11 +223,16 @@ const StyledSeverityContent = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--echoes-dimension-space-25);
+  gap: var(--echoes-dimension-space-50);
 `;
 
 const StyledSeverityText = styled.span`
   font: var(--echoes-typography-text-small-medium);
+`;
+
+const StyledDropdownIndicator = styled.div`
+  margin-left: calc(var(--echoes-dimension-space-25) * -1);
+  margin-right: calc(var(--echoes-dimension-space-25) * -1);
 `;
 
 const StyledButtonIconStyled = styled(ButtonIconStyled)`

--- a/src/components/badges/BadgeSeverity.tsx
+++ b/src/components/badges/BadgeSeverity.tsx
@@ -54,6 +54,7 @@ export enum BadgeSeverityVariety {
 
 type excludedButtonProps = 'isLoading' | 'size' | 'variety' | 'isDisabled';
 type InheritedButtonProps = Omit<ButtonBaseProps, excludedButtonProps> &
+  Pick<ButtonIconProps, 'isIconFilled' | 'tooltipContent' | 'tooltipOptions'>;
 
 export interface BadgeSeverityProps extends InheritedButtonProps {
   /**
@@ -188,8 +189,13 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
           ref={ref}
           type="button">
           <StyledSeverityContent>
-            {isLoading && <SpinnerOverrideColor isLoading={isLoading} />}
-            {!isLoading && <SeverityIcon />}
+            <SpinnerOverrideColor
+              css={{
+                marginRight: 'var(--echoes-dimension-space-50)',
+              }}
+              isLoading={isLoading}>
+              <SeverityIcon />
+            </SpinnerOverrideColor>
             <StyledSeverityText>{severityLabel}</StyledSeverityText>
             {variety === BadgeSeverityVariety.Dropdown && (
               <StyledDropdownIndicator>
@@ -233,7 +239,10 @@ const StyledSeverityContent = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--echoes-dimension-space-50);
+
+  & > *:not(:first-child):not(:last-child) {
+    margin-right: var(--echoes-dimension-space-50);
+  }
 `;
 
 const StyledSeverityText = styled.span`

--- a/src/components/badges/BadgeSeverity.tsx
+++ b/src/components/badges/BadgeSeverity.tsx
@@ -46,7 +46,13 @@ export enum BadgeSeverityLevel {
   Info = 'info',
 }
 
-type excludedButtonProps = 'isLoading' | 'size' | 'variety';
+export enum BadgeSeverityVariety {
+  Clickable = 'clickable',
+  Dropdown = 'dropdown',
+  Static = 'static',
+}
+
+type excludedButtonProps = 'isLoading' | 'size' | 'variety' | 'isDisabled';
 type InheritedButtonProps = Omit<ButtonCommonProps, excludedButtonProps> &
   Pick<ButtonIconProps, 'isIconFilled' | 'tooltipContent' | 'tooltipOptions'>;
 
@@ -64,11 +70,6 @@ export interface BadgeSeverityProps extends InheritedButtonProps {
   ariaLabel: string;
 
   /**
-   * Indicates that this badge opens a dropdown menu.
-   */
-  hasDropdownIndicator?: boolean;
-
-  /**
    * Indicates whether the badge is in a loading state, which will replace the button's icon with the spinner
    */
   isLoading?: boolean;
@@ -83,6 +84,11 @@ export interface BadgeSeverityProps extends InheritedButtonProps {
    * Must match `BadgeSeverityLevel`.
    */
   severity: `${BadgeSeverityLevel}`;
+
+  /**
+   * The variety of the badge.
+   */
+  variety?: BadgeSeverityVariety;
 }
 
 export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((props, ref) => {
@@ -91,8 +97,6 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
     ariaLabel,
     className,
     hasAutoFocus = false,
-    hasDropdownIndicator = false,
-    isDisabled = false,
     isIconFilled = false,
     isLoading = false,
     onClick,
@@ -102,10 +106,17 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
     shouldStopPropagation = false,
     tooltipContent = props.ariaLabel,
     tooltipOptions = {},
+    variety = BadgeSeverityVariety.Clickable,
     ...htmlProps
   } = props;
 
-  const handleClick = useButtonClickHandler(props);
+  const isDisabled = variety === BadgeSeverityVariety.Static;
+
+  const handleClick = useButtonClickHandler({
+    ...props,
+    isDisabled,
+  });
+
   const { formatMessage } = useIntl();
 
   const SeverityIcon = BADGE_SEVERITY_ICON[severity];
@@ -181,7 +192,7 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
             {isLoading && <SpinnerOverrideColor isLoading={isLoading} />}
             {!isLoading && <SeverityIcon />}
             <StyledSeverityText>{severityLabel}</StyledSeverityText>
-            {!isDisabled && hasDropdownIndicator && (
+            {variety === BadgeSeverityVariety.Dropdown && (
               <StyledDropdownIndicator>
                 <IconChevronDown />
               </StyledDropdownIndicator>

--- a/src/components/badges/BadgeSeverity.tsx
+++ b/src/components/badges/BadgeSeverity.tsx
@@ -26,6 +26,7 @@ import { ButtonIconProps } from '../buttons/ButtonIcon';
 import { ButtonIconStyled, ButtonText } from '../buttons/ButtonStyles';
 import { ButtonCommonProps } from '../buttons/ButtonTypes';
 import {
+  IconChevronDown,
   IconInfo,
   IconSeverityBlocker,
   IconSeverityHigh,
@@ -35,6 +36,7 @@ import {
 import { IconFilledProps } from '../icons/IconWrapper';
 import { SpinnerOverrideColor } from '../spinner/SpinnerOverrideColor';
 import { Tooltip } from '../tooltip';
+import { useIntl } from 'react-intl';
 
 export enum BadgeSeverityLevel {
   Blocker = 'blocker',
@@ -98,8 +100,37 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
   } = props;
 
   const handleClick = useButtonClickHandler(props);
+  const { formatMessage } = useIntl();
 
   const SeverityIcon = BADGE_SEVERITY_ICON[severity];
+  const BADGE_SEVERITY_LABEL = {
+    [BadgeSeverityLevel.Blocker]: formatMessage({
+      id: 'severity_impact.BLOCKER',
+      defaultMessage: 'Blocker',
+      description: 'Label for blocker severity level',
+    }),
+    [BadgeSeverityLevel.High]: formatMessage({
+      id: 'severity_impact.HIGH',
+      defaultMessage: 'High',
+      description: 'Label for high severity level',
+    }),
+    [BadgeSeverityLevel.Info]: formatMessage({
+      id: 'severity_impact.INFO',
+      defaultMessage: 'Info',
+      description: 'Label for info severity level',
+    }),
+    [BadgeSeverityLevel.Low]: formatMessage({
+      id: 'severity_impact.LOW',
+      defaultMessage: 'Low',
+      description: 'Label for low severity level',
+    }),
+    [BadgeSeverityLevel.Medium]: formatMessage({
+      id: 'severity_impact.MEDIUM',
+      defaultMessage: 'Medium',
+      description: 'Label for medium severity level',
+    }),
+  };
+  const severityLabel = BADGE_SEVERITY_LABEL[severity];
 
   return (
     <StyledWrapper
@@ -123,13 +154,11 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
           autoFocus={hasAutoFocus}
           css={useMemo(
             () => ({
-              '--button-padding': 'var(--echoes-dimension-space-0)',
-              '--button-height': 'var(--echoes-dimension-height-600)',
-              '--button-width': 'var(--echoes-dimension-height-600)',
+              '--button-padding': 'var(--echoes-dimension-space-50)',
+              '--button-height': 'auto',
+              '--button-width': 'auto',
 
-              '--button-color': 'var(----badge-severity-icon-color)',
-              '--button-border':
-                'var(----badge-severity-border-color) solid var(--echoes-border-width-default)',
+              '--button-border': 'inherit solid var(--echoes-border-width-default)',
               '--button-background': 'var(--badge-severity-icon-background-color)',
               '--button-background-focus': 'var(--badge-severity-icon-background-color)',
               '--button-background-disabled': 'var(--badge-severity-icon-background-color)',
@@ -142,13 +171,17 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
           onClick={handleClick}
           ref={ref}
           type="button">
-          {isDefined(isLoading) ? (
-            <SpinnerOverrideColor isLoading={isLoading}>
+          <StyledSeverityContent>
+            {isDefined(isLoading) ? (
+              <SpinnerOverrideColor isLoading={isLoading}>
+                <SeverityIcon />
+              </SpinnerOverrideColor>
+            ) : (
               <SeverityIcon />
-            </SpinnerOverrideColor>
-          ) : (
-            <SeverityIcon />
-          )}
+            )}
+            <StyledSeverityText>{severityLabel}</StyledSeverityText>
+            {!isDisabled && <IconChevronDown />}
+          </StyledSeverityContent>
         </StyledButtonIconStyled>
       </Tooltip>
     </StyledWrapper>
@@ -179,6 +212,17 @@ const StyledContent = styled.div`
   flex-direction: row;
   padding: var(--echoes-dimension-space-50) var(--echoes-dimension-space-75);
   gap: var(--echoes-dimension-space-50);
+`;
+
+const StyledSeverityContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--echoes-dimension-space-25);
+`;
+
+const StyledSeverityText = styled.span`
+  font: var(--echoes-typography-text-small-medium);
 `;
 
 const StyledButtonIconStyled = styled(ButtonIconStyled)`

--- a/stories/badges/BadgeSeverity-stories.tsx
+++ b/stories/badges/BadgeSeverity-stories.tsx
@@ -22,6 +22,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { BadgeSeverity, BadgeSeverityLevel, DropdownMenu } from '../../src';
 import { iconsComponentsArgType } from '../helpers/arg-types';
 import { basicWrapperDecorator } from '../helpers/BasicWrapper';
+import { BadgeSeverityVariety } from '../../src/components/badges/BadgeSeverity';
 
 const { mapping, options = [] } = iconsComponentsArgType;
 
@@ -53,7 +54,7 @@ export const Default: Story = {
     ariaLabel: 'Click to open severity dropdown',
     quality: 'Maintainability',
     severity: 'high',
-    hasDropdownIndicator: true,
+    variety: BadgeSeverityVariety.Dropdown,
   },
   render: (args) => (
     <DropdownMenu
@@ -71,12 +72,12 @@ export const Default: Story = {
   ),
 };
 
-export const Disabled: Story = {
+export const Static: Story = {
   args: {
     ariaLabel: 'Disabled severity badge',
     quality: 'Maintainability',
     severity: 'medium',
-    isDisabled: true,
+    variety: BadgeSeverityVariety.Static,
   },
 };
 

--- a/stories/badges/BadgeSeverity-stories.tsx
+++ b/stories/badges/BadgeSeverity-stories.tsx
@@ -79,7 +79,6 @@ export const Disabled: Story = {
   },
 };
 
-
 export const AllSeverities: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', alignItems: 'start' }}>

--- a/stories/badges/BadgeSeverity-stories.tsx
+++ b/stories/badges/BadgeSeverity-stories.tsx
@@ -53,6 +53,7 @@ export const Default: Story = {
     ariaLabel: 'Click to open severity dropdown',
     quality: 'Maintainability',
     severity: 'high',
+    hasDropdownIndicator: true,
   },
   render: (args) => (
     <DropdownMenu

--- a/stories/badges/BadgeSeverity-stories.tsx
+++ b/stories/badges/BadgeSeverity-stories.tsx
@@ -50,19 +50,44 @@ type Story = StoryObj<typeof BadgeSeverity>;
 
 export const Default: Story = {
   args: {
-    ariaLabel: 'Click to open dropdown',
-    quality: 'Reliability',
+    ariaLabel: 'Click to open severity dropdown',
+    quality: 'Maintainability',
     severity: 'high',
   },
   render: (args) => (
     <DropdownMenu
       items={
         <>
-          <DropdownMenu.ItemButton>option 1</DropdownMenu.ItemButton>
-          <DropdownMenu.ItemButton>option 2</DropdownMenu.ItemButton>
+          <DropdownMenu.ItemButton>Blocker</DropdownMenu.ItemButton>
+          <DropdownMenu.ItemButton>High</DropdownMenu.ItemButton>
+          <DropdownMenu.ItemButton>Medium</DropdownMenu.ItemButton>
+          <DropdownMenu.ItemButton>Low</DropdownMenu.ItemButton>
+          <DropdownMenu.ItemButton>Info</DropdownMenu.ItemButton>
         </>
       }>
       <BadgeSeverity {...args} />
     </DropdownMenu>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    ariaLabel: 'Disabled severity badge',
+    quality: 'Maintainability',
+    severity: 'medium',
+    isDisabled: true,
+  },
+};
+
+
+export const AllSeverities: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', alignItems: 'start' }}>
+      <BadgeSeverity ariaLabel="Blocker severity" quality="Security" severity="blocker" />
+      <BadgeSeverity ariaLabel="High severity" quality="Reliability" severity="high" />
+      <BadgeSeverity ariaLabel="Medium severity" quality="Maintainability" severity="medium" />
+      <BadgeSeverity ariaLabel="Low severity" quality="Security" severity="low" />
+      <BadgeSeverity ariaLabel="Info severity" quality="Reliability" severity="info" />
+    </div>
   ),
 };

--- a/stories/badges/BadgeSeverity-stories.tsx
+++ b/stories/badges/BadgeSeverity-stories.tsx
@@ -74,7 +74,7 @@ export const Default: Story = {
 
 export const Static: Story = {
   args: {
-    ariaLabel: 'Disabled severity badge',
+    ariaLabel: 'Static severity badge',
     quality: 'Maintainability',
     severity: 'medium',
     variety: BadgeSeverityVariety.Static,


### PR DESCRIPTION
[ECHOES-807](https://sonarsource.atlassian.net/browse/ECHOES-807)

Preview https://deploy-preview-400--echoes-react.netlify.app/?path=/docs/echoes-badges-badgeseverity--docs

This has a few differences from the story. 

* `isActionable` is redundant to an existing prop, `isDisabled`.  Chose to not break existing API
* `hasDropdownIndicator` is redundant to both `isActionable` and `isDisabled`.  This badge only has 2 states: Actionable and not Actionable.  Actionable badges have a dropdown menu.

These 2 states (plus hover and focus variants) are documented at https://www.figma.com/design/3bo9DCW9JD52Lc21Fcyea8/branch/QdThWVaQSBJ37aZIX4MMZ3/-0.22.0-Echoes--Components?node-id=11653-3297&m=dev

Figma should be updated with the `isDisabled` prop rather than introducing a new one I think.



[ECHOES-807]: https://sonarsource.atlassian.net/browse/ECHOES-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ