### PR TITLE
ECHOES-790 Fix DropdownMenu items' overflow handling

### DIFF
--- a/src/components/dropdown-menu/DropdownMenuItemBase.tsx
+++ b/src/components/dropdown-menu/DropdownMenuItemBase.tsx
@@ -150,6 +150,7 @@ const StyledLeftHandSide = styled.div`
   align-items: center;
   column-gap: var(--echoes-dimension-space-100);
   display: flex;
+  min-width: 0; // Necessary for ellipsis
   flex: 1 1 auto;
   justify-content: flex-start;
 `;
@@ -164,6 +165,8 @@ const StyledLabelAndHelpText = styled.div`
 `;
 
 const StyledLabel = styled.span`
+  overflow: hidden;
+
   &,
   * {
     text-overflow: ellipsis;
@@ -197,10 +200,6 @@ const StyledRadixDropdownMenuItem = styled(radixDropdownMenu.Item)`
   padding: var(--echoes-dimension-space-100) var(--echoes-dimension-space-150);
 
   cursor: pointer;
-
-  * {
-    overflow: hidden;
-  }
 
   &:focus-visible {
     border-radius: var(--echoes-border-radius-400);

--- a/stories/dropdown-menu/DropdownMenu-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenu-stories.tsx
@@ -21,6 +21,7 @@
 import styled from '@emotion/styled';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
+  Badge,
   DropdownMenu,
   DropdownMenuAlign,
   IconBug,
@@ -45,17 +46,6 @@ export default meta;
 
 type Story = StoryObj<typeof DropdownMenu>;
 
-const StyledBadge = styled.span`
-  background-color: var(--echoes-color-background-default-active);
-  border-radius: 4px;
-  color: var(--echoes-color-text-default);
-  font: var(--echoes-typography-text-small-semi-bold);
-  margin-left: 1rem;
-  padding: 0px 8px;
-  text-transform: uppercase;
-  vertical-align: middle;
-`;
-
 const items = (
   <>
     <DropdownMenu.ItemButton>Your account</DropdownMenu.ItemButton>
@@ -68,7 +58,7 @@ const items = (
 
     <DropdownMenu.ItemButton
       prefix={<IconGear color="echoes-color-icon-bold" />}
-      suffix={<StyledBadge>Public</StyledBadge>}>
+      suffix={<Badge variety="info">Public</Badge>}>
       SonarQube Cloud
     </DropdownMenu.ItemButton>
 


### PR DESCRIPTION
[ECHOES-819](https://sonarsource.atlassian.net/browse/ECHOES-819)

Easily validate by adding a badge as a suffix and adding lots of text in the label.

The ellipsis should kick in, and the badge should still be rendered appropriately

[ECHOES-819]: https://sonarsource.atlassian.net/browse/ECHOES-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ