### PR TITLE
ECHOES-645 Allow helpText with no label

### DIFF
--- a/src/common/helpers/test-utils.tsx
+++ b/src/common/helpers/test-utils.tsx
@@ -22,7 +22,7 @@ import userEvent, { Options as UserEventsOptions } from '@testing-library/user-e
 import React, { ComponentProps, PropsWithChildren } from 'react';
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
-import { PropsWithLabels } from '~types/utils';
+import { PropsWithLabels, PropsWithLabelsAndHelpText } from '~types/utils';
 import { EchoesProvider } from '../../components/echoes-provider';
 
 export function render(
@@ -43,6 +43,11 @@ function ContextWrapper({ children }: PropsWithChildren<{}>) {
     </IntlProvider>
   );
 }
+
+export type OmitPropsWithLabelsAndHelpText<T extends React.JSXElementConstructor<any>> = Partial<
+  Omit<ComponentProps<T>, keyof PropsWithLabelsAndHelpText<{}>>
+> &
+  PropsWithLabelsAndHelpText<{}>;
 
 export type OmitPropsWithLabels<T extends React.JSXElementConstructor<any>> = Partial<
   Omit<ComponentProps<T>, keyof PropsWithLabels<{}>>

--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -20,7 +20,7 @@
 import styled from '@emotion/styled';
 import { type ReactNode, type RefAttributes, forwardRef, useId, useMemo } from 'react';
 import { GroupAlignment } from '~types/GroupAlignment';
-import { PropsWithLabels } from '~types/utils';
+import { PropsWithLabels, TextNodeOptional } from '~types/utils';
 import { type CheckboxProps, Checkbox } from '../checkbox/Checkbox';
 import {
   type ValidationProps,
@@ -214,6 +214,10 @@ interface CheckboxGroupPropsBase<T>
    * Add a `class` attribute to the root element (optional).
    */
   className?: string;
+  /**
+   * Optional text to display under the group
+   */
+  helpText?: TextNodeOptional;
   /**
    * The ID of the element with the role `group` (optional).
    */

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -21,7 +21,7 @@
 import styled from '@emotion/styled';
 import * as RadixCheckbox from '@radix-ui/react-checkbox';
 import { forwardRef, useCallback, useId } from 'react';
-import { PropsWithLabels } from '~types/utils';
+import { PropsWithLabelsAndHelpText } from '~types/utils';
 import { FormFieldLabel } from '../form/FormFieldLabel';
 import { Spinner } from '../spinner';
 import { HelperText } from '../typography';
@@ -40,7 +40,7 @@ interface CheckboxPropsBase {
   title?: string;
 }
 
-export type CheckboxProps = PropsWithLabels<CheckboxPropsBase>;
+export type CheckboxProps = PropsWithLabelsAndHelpText<CheckboxPropsBase>;
 
 export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>((props, ref) => {
   const {

--- a/src/components/checkbox/__tests__/Checkbox-test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox-test.tsx
@@ -21,7 +21,7 @@
 import { screen } from '@testing-library/react';
 import { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { ComponentProps } from 'react';
-import { OmitPropsWithLabels, render } from '~common/helpers/test-utils';
+import { OmitPropsWithLabelsAndHelpText, render } from '~common/helpers/test-utils';
 import { Tooltip } from '../../tooltip';
 import { Checkbox } from '../Checkbox';
 
@@ -146,7 +146,7 @@ it('should correctly support tooltips', async () => {
   expect(screen.getByRole('tooltip', { name: 'my tooltip' })).toBeInTheDocument();
 });
 
-function setupCheckbox(props: OmitPropsWithLabels<typeof Checkbox>) {
+function setupCheckbox(props: OmitPropsWithLabelsAndHelpText<typeof Checkbox>) {
   const { rerender: rtlRerender, ...rest } = render(
     <Checkbox checked onCheck={jest.fn()} {...props} />,
     undefined,
@@ -156,7 +156,7 @@ function setupCheckbox(props: OmitPropsWithLabels<typeof Checkbox>) {
   );
   return {
     rerender(override: Partial<ComponentProps<typeof Checkbox>>) {
-      const newProps = { ...props, ...override } as OmitPropsWithLabels<typeof Checkbox>;
+      const newProps = { ...props, ...override } as OmitPropsWithLabelsAndHelpText<typeof Checkbox>;
       rtlRerender(<Checkbox checked onCheck={jest.fn()} {...newProps} />);
     },
     ...rest,

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -23,7 +23,7 @@ import * as radixDropdownMenu from '@radix-ui/react-dropdown-menu';
 import { ReactNode, forwardRef, useContext } from 'react';
 import { truncate } from '~common/helpers/styles';
 import { isDefined } from '~common/helpers/types';
-import { PropsLabel } from '~types/utils';
+import { PropsLabelAndHelpText } from '~types/utils';
 import { THEME_DATA_ATTRIBUTE, ThemeContext } from '~utils/theme';
 import { PortalContext } from '../../common/components/PortalContext';
 import { HelperText, Label } from '../typography';
@@ -47,7 +47,7 @@ export interface DropdownMenuProps extends radixDropdownMenu.DropdownMenuTrigger
   align?: DropdownMenuAlign;
   children: ReactNode;
   className?: string;
-  header?: Pick<PropsLabel, 'helpText' | 'label'> & { suffix?: ReactNode };
+  header?: Pick<PropsLabelAndHelpText, 'helpText' | 'label'> & { suffix?: ReactNode };
   id?: string;
   isDisabled?: boolean;
   isModal?: boolean;

--- a/src/components/radio-button-group/RadioButtonTypes.ts
+++ b/src/components/radio-button-group/RadioButtonTypes.ts
@@ -20,6 +20,7 @@
 
 import { ReactNode } from 'react';
 import { GroupAlignment } from '~types/GroupAlignment';
+import { TextNodeOptional } from '~types/utils';
 import { FormFieldProps, ValidationProps } from '../form/FormField';
 
 type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletipProps' | 'width'>;
@@ -54,6 +55,11 @@ export interface RadioButtonGroupProps extends ValidationProps, FormFieldPropsSu
    * The default selected value (uncontrolled).
    */
   defaultValue?: string;
+
+  /**
+   * Optional text to display under the group
+   */
+  helpText?: TextNodeOptional;
 
   /**
    * The unique identifier for the radio button group.

--- a/src/components/select/SelectCommons.tsx
+++ b/src/components/select/SelectCommons.tsx
@@ -25,7 +25,7 @@ import { forwardRef, useContext, useEffect, useId } from 'react';
 import { useIntl } from 'react-intl';
 import { isDefined, isStringDefined } from '~common/helpers/types';
 import { useForwardedRefWithState } from '~common/helpers/useForwardedRef';
-import { PropsWithLabels } from '~types/utils';
+import { PropsWithLabels, TextNodeOptional } from '~types/utils';
 import { IconChevronDown, IconX, Spinner } from '..';
 import { PortalContext } from '../../common/components/PortalContext';
 import {
@@ -47,6 +47,7 @@ export interface SelectBaseProps extends ValidationProps, FormFieldPropsSubset {
   defaultValue?: MantineSelectProps['defaultValue'];
   filter?: SelectFilterFunction;
   hasDropdownAutoWidth?: boolean;
+  helpText?: TextNodeOptional;
   highlight?: SelectHighlight;
   isDisabled?: boolean;
   isLoading?: boolean;

--- a/src/components/text-input/TextInputBase.tsx
+++ b/src/components/text-input/TextInputBase.tsx
@@ -19,6 +19,7 @@
  */
 import styled from '@emotion/styled';
 import { InputHTMLAttributes } from 'react';
+import { TextNodeOptional } from '~types/utils';
 import { type ValidationProps, FormFieldProps } from '../form/FormField';
 
 type InputEventAttributesSubset =
@@ -40,6 +41,7 @@ type FormFieldPropsSubset = Pick<FormFieldProps, 'helpToggletipProps' | 'isRequi
 
 export interface InputProps extends ValidationProps, FormFieldPropsSubset {
   className?: string;
+  helpText?: TextNodeOptional;
   isDisabled?: boolean;
   placeholder?: string;
   value?: string | number;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -28,6 +28,9 @@ export interface PropsLabel {
   ariaLabelledBy?: never;
   id?: string;
   label: TextNode;
+}
+
+export interface PropsLabelAndHelpText extends PropsLabel {
   helpText?: TextNodeOptional;
 }
 
@@ -36,6 +39,9 @@ export interface PropsAriaLabel {
   ariaLabelledBy?: never;
   id?: string;
   label?: never;
+}
+
+export interface PropsAriaLabelAndHelpText extends PropsAriaLabel {
   helpText?: never;
 }
 
@@ -44,6 +50,9 @@ export interface PropsAriaLabelledBy {
   ariaLabelledBy: string;
   id?: string;
   label?: never;
+}
+
+export interface PropsAriaLabelledByAndHelpText extends PropsAriaLabelledBy {
   helpText?: never;
 }
 
@@ -52,8 +61,19 @@ export interface PropsAriaLabelViaId {
   ariaLabelledBy?: never;
   id: string;
   label?: never;
+}
+
+export interface PropsAriaLabelViaIdAndHelpText extends PropsAriaLabelViaId {
   helpText?: never;
 }
+
+export type PropsWithLabelsAndHelpText<T> = T &
+  (
+    | PropsLabelAndHelpText
+    | PropsAriaLabelAndHelpText
+    | PropsAriaLabelledByAndHelpText
+    | PropsAriaLabelViaIdAndHelpText
+  );
 
 export type PropsWithLabels<T> = T &
   (PropsLabel | PropsAriaLabel | PropsAriaLabelledBy | PropsAriaLabelViaId);

--- a/stories/select/Select-stories.tsx
+++ b/stories/select/Select-stories.tsx
@@ -26,15 +26,20 @@ import {
   iconsElementsArgType,
   toDisabledControlArgType,
 } from '../helpers/arg-types';
+import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof Select> = {
   component: Select,
   title: 'Echoes/Select/Select',
+  args: {
+    width: 'large',
+  },
   argTypes: {
     ...formFieldsArgTypes,
     valueIcon: iconsElementsArgType,
     ...toDisabledControlArgType('onChange', 'onOpen'),
   },
+  decorators: [basicWrapperDecorator],
 };
 
 export default meta;
@@ -103,6 +108,16 @@ export const Plain: Story = {
     data,
     isRequired: true,
     width: FormFieldWidth.Medium,
+  },
+  render: (args) => <SelectContainer {...args} />,
+};
+
+export const HelpTextNoLabel: Story = {
+  args: {
+    label: undefined,
+    helpText: 'This is very helpful information',
+    data,
+    optionComponent: Custom,
   },
   render: (args) => <SelectContainer {...args} />,
 };


### PR DESCRIPTION
[ECHOES-645](https://sonarsource.atlassian.net/browse/ECHOES-645)

Allowing helpText with no label on the following components:

- CheckboxGroup
- RadioButtonGroup
- Select
- SelectAsync
- TextArea
- TextInput

Only the Checkbox & DropdownMenuItems keep the restriction of needing a label for the helpText, because of their structure

[ECHOES-645]: https://sonarsource.atlassian.net/browse/ECHOES-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ