### PR TITLE
Move html props down after the rest of the props to allow overrides

### DIFF
--- a/src/common/components/DismissButton.tsx
+++ b/src/common/components/DismissButton.tsx
@@ -38,11 +38,11 @@ export const DismissButton = forwardRef<HTMLButtonElement, DismissButtonProps>((
   return (
     <Tooltip content={ariaLabel}>
       <DismissButtonStyled
-        {...htmlProps}
         aria-label={ariaLabel}
         onClick={handleClick}
         ref={ref}
-        type="button">
+        type="button"
+        {...htmlProps}>
         <IconX />
       </DismissButtonStyled>
     </Tooltip>

--- a/src/components/badges/Badge.tsx
+++ b/src/components/badges/Badge.tsx
@@ -94,7 +94,6 @@ export const Badge = forwardRef<HTMLButtonElement, BadgeProps>((props, ref) => {
 
   return (
     <StyledBadge
-      {...otherProps}
       aria-label={ariaLabel}
       as={isInteractive ? 'button' : 'span'}
       css={useMemo(
@@ -109,7 +108,7 @@ export const Badge = forwardRef<HTMLButtonElement, BadgeProps>((props, ref) => {
       isInteractive={isInteractive}
       ref={ref}
       type="button" // ignored when rendering a span
-    >
+      {...otherProps}>
       {isDefined(IconLeft) && <IconLeft isFilled={isIconFilled} />}
       {children}
     </StyledBadge>

--- a/src/components/badges/BadgeSeverity.tsx
+++ b/src/components/badges/BadgeSeverity.tsx
@@ -167,7 +167,6 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
 
       <Tooltip content={tooltipContent} {...tooltipOptions}>
         <StyledButtonIconStyled
-          {...htmlProps}
           aria-label={ariaLabel}
           autoFocus={hasAutoFocus}
           css={useMemo(
@@ -188,7 +187,8 @@ export const BadgeSeverity = forwardRef<HTMLButtonElement, BadgeSeverityProps>((
           disabled={isDisabled}
           onClick={handleClick}
           ref={ref}
-          type="button">
+          type="button"
+          {...htmlProps}>
           <StyledSeverityContent>
             <Spinner isLoading={isLoading}>
               <SeverityIcon />

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -83,14 +83,14 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
 
       return (
         <ButtonAsLink
-          {...restProps}
           {...getShouldOpenInNewTabProps({ enableOpenInNewTab, to })}
           aria-label={ariaLabel}
           autoFocus={hasAutoFocus}
           css={commonStyles}
           onClick={handleClick}
           ref={ref as ForwardedRef<HTMLAnchorElement>}
-          to={to}>
+          to={to}
+          {...restProps}>
           <ButtonContent
             isLoading={isLoading}
             prefix={prefix}
@@ -106,14 +106,14 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
 
     return (
       <ButtonStyled
-        {...htmlProps}
         aria-label={ariaLabel}
         autoFocus={hasAutoFocus}
         css={commonStyles}
         disabled={isDisabled}
         onClick={handleClick}
         ref={ref as ForwardedRef<HTMLButtonElement>}
-        type={type}>
+        type={type}
+        {...htmlProps}>
         <ButtonContent isLoading={isLoading} prefix={prefix} suffix={suffix}>
           {children}
         </ButtonContent>

--- a/src/components/buttons/ButtonIcon.tsx
+++ b/src/components/buttons/ButtonIcon.tsx
@@ -105,14 +105,14 @@ export const ButtonIcon = forwardRef<HTMLButtonElement | HTMLAnchorElement, Butt
       return (
         <Tooltip content={tooltipContent} {...tooltipOptions}>
           <ButtonIconAsLink
-            {...restProps}
             {...getShouldOpenInNewTabProps({ enableOpenInNewTab, to })}
             aria-label={ariaLabel}
             autoFocus={hasAutoFocus}
             css={commonStyles}
             onClick={handleClick}
             ref={ref as ForwardedRef<HTMLAnchorElement>}
-            to={to}>
+            to={to}
+            {...restProps}>
             <ButtonIconContent Icon={Icon} isIconFilled={isIconFilled} isLoading={isLoading} />
           </ButtonIconAsLink>
         </Tooltip>
@@ -125,14 +125,14 @@ export const ButtonIcon = forwardRef<HTMLButtonElement | HTMLAnchorElement, Butt
     return (
       <Tooltip content={tooltipContent} {...tooltipOptions}>
         <ButtonIconStyled
-          {...htmlProps}
           aria-label={ariaLabel}
           autoFocus={hasAutoFocus}
           css={commonStyles}
           disabled={isDisabled}
           onClick={handleClick}
           ref={ref as ForwardedRef<HTMLButtonElement>}
-          type={type}>
+          type={type}
+          {...htmlProps}>
           <ButtonIconContent Icon={Icon} isIconFilled={isIconFilled} isLoading={isLoading} />
         </ButtonIconStyled>
       </Tooltip>

--- a/src/components/dropdown-menu/DropdownMenuItemBase.tsx
+++ b/src/components/dropdown-menu/DropdownMenuItemBase.tsx
@@ -117,13 +117,13 @@ export const DropdownMenuItemBase = forwardRef<HTMLDivElement, Props>((props, re
 
   return (
     <MenuItemComponent
-      {...radixProps}
       aria-label={ariaLabel}
       {...(isItemWrapped ? { asChild: true } : {})}
       className={className}
       disabled={isDisabled}
       onClick={isDisabled ? undefined : onClick}
-      ref={ref}>
+      ref={ref}
+      {...radixProps}>
       {itemContainer}
     </MenuItemComponent>
   );

--- a/src/components/radio-button-group/RadioButtonGroup.tsx
+++ b/src/components/radio-button-group/RadioButtonGroup.tsx
@@ -76,7 +76,6 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Radio
         validationMessageId={validationMessageId}
         width={width}>
         <RadioGroupRoot
-          {...radixRadioGroupProps}
           aria-describedby={describedBy}
           aria-invalid={validation === FormFieldValidation.Invalid}
           aria-label={ariaLabel}
@@ -86,7 +85,8 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Radio
           id={controlId}
           onValueChange={onChange}
           ref={ref}
-          required={required}>
+          required={required}
+          {...radixRadioGroupProps}>
           <RadioButtonsWrapper>
             {options.map(({ isDisabled: disabledOption, ...o }) => (
               <RadioButton

--- a/src/components/search-input/SearchInputClearButton.tsx
+++ b/src/components/search-input/SearchInputClearButton.tsx
@@ -39,11 +39,11 @@ export const SearchInputClearButton = forwardRef<HTMLButtonElement, SearchInputC
 
     return (
       <SearchInputClearButtonStyled
-        {...htmlProps}
         aria-label={ariaLabel}
         onClick={handleClick}
         ref={ref}
-        type="button">
+        type="button"
+        {...htmlProps}>
         <IconX />
       </SearchInputClearButtonStyled>
     );

--- a/src/components/selection-cards/SelectionCards.tsx
+++ b/src/components/selection-cards/SelectionCards.tsx
@@ -98,7 +98,6 @@ export const SelectionCards = forwardRef<HTMLDivElement, SelectionCardsProps>((p
 
   return (
     <SelectionCardsRoot
-      {...radixRadioGroupProps}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       className={className}
@@ -107,7 +106,8 @@ export const SelectionCards = forwardRef<HTMLDivElement, SelectionCardsProps>((p
       id={id ?? defaultId}
       onValueChange={onChange}
       ref={ref}
-      value={value}>
+      value={value}
+      {...radixRadioGroupProps}>
       {options.map(({ isDisabled: disabledOption, ...o }) => (
         <SelectionCard
           isDisabled={disabled ? true : disabledOption} // Group disabled takes precedence


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

We had quite a few usage of `aria-label` for buttons in the products, which would be remplaced by an empty `ariaLabel` props. The correct way to set an accessible label on these components is the `ariaLabel` prop but it seems a bit harsh to just dismiss usage of `aria-label` if someone makes a mistake, so I think this would just make it work all the time.
