### PR TITLE
SCA-951 [NO-JIRA] fix BadgeSeverity icon color

### DIFF
--- a/src/components/badges/BadgeSeverity.tsx
+++ b/src/components/badges/BadgeSeverity.tsx
@@ -261,7 +261,6 @@ const StyledSeverityText = styled.span`
 `;
 StyledSeverityText.displayName = 'StyledSeverityText';
 
-
 const StyledDropdownIndicator = styled.div`
   margin-left: calc(${cssVar('dimension-space-25')} * -1);
   margin-right: calc(${cssVar('dimension-space-25')} * -1);


### PR DESCRIPTION
[SCA-951](https://sonarsource.atlassian.net/browse/SCA-951)

This is part of the fix for https://sonarsource.atlassian.net/browse/SCA-934

BadgeSeverity was not using the icon-specific colors. 


[SCA-951]: https://sonarsource.atlassian.net/browse/SCA-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ