### PR TITLE
ECHOES-966 Make it possible to manually run the releasability check, re-enable releasbility check on release job

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       statuses: write
       contents: read
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: SonarSource/gh-action_releasability/releasability-status@v3
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToNpmJS: true
-      skipJavascriptReleasabilityChecks: true # Temporary, until the releasability version check handles an `rc` suffix
+      skipJavascriptReleasabilityChecks: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
[ECHOES-966](https://sonarsource.atlassian.net/browse/ECHOES-966)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[ECHOES-966]: https://sonarsource.atlassian.net/browse/ECHOES-966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ