### PR TITLE
BUILD-10954 Use npm Trusted Publisher for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     with:
       publishToNpmJS: true
       skipJavascriptReleasabilityChecks: false
+      useNpmTrustedPublisher: true
+      githubEnvironment: release
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## What

Set `useNpmTrustedPublisher: true` and `githubEnvironment: release` in the release workflow to enable OIDC-based npm publishing via npm Trusted Publishers.

## Why

Part of [BUILD-10825](https://sonarsource.atlassian.net/browse/BUILD-10825) — migrating npm deployments from persistent Vault tokens to short-lived OIDC tokens via GitHub Actions Trusted Publishers.

Pre-requisites already completed:
- npm Trusted Publisher configured on npmjs.org for `echoes-react`
- GitHub Environment `release` created, restricted to tags


Further read: https://docs.npmjs.com/trusted-publishers/#supported-cicd-providers

[BUILD-10825]: https://sonarsource.atlassian.net/browse/BUILD-10825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ