### PR TITLE
ECHOES-1309 Fix sticky PageHeader goes under PageContent elements with z-index or new stacking context

### DIFF
--- a/src/components/layout/LayoutSlots.tsx
+++ b/src/components/layout/LayoutSlots.tsx
@@ -140,6 +140,7 @@ export const PageContent = styled.main`
   grid-area: ${PageGridArea.main};
 
   padding: ${cssVar('dimension-space-300')};
+  isolation: isolate; // Prevent content z-index values from escaping and overlapping a sticky PageHeader
 `;
 PageContent.displayName = 'PageContent';
 

--- a/src/components/layout/header/page-header/PageHeader.tsx
+++ b/src/components/layout/header/page-header/PageHeader.tsx
@@ -79,6 +79,7 @@ const StyledPageHeader = styled(StyledHeaderBase)`
 
   &[data-scroll-behavior='${PageHeaderScrollBehavior.collapse}'] {
     position: sticky;
+    z-index: 1; // Ensure the page header is showing over the content when sticky
     // The top position is the target height from which we remove the total height and the top margin
     top: calc(
       ${cssVar('layout-page-header-sizes-height-collapsed')} - var(--page-header-total-height) -
@@ -88,6 +89,7 @@ const StyledPageHeader = styled(StyledHeaderBase)`
 
   &[data-scroll-behavior='${PageHeaderScrollBehavior.sticky}'] {
     position: sticky;
+    z-index: 1; // Ensure the page header is showing over the content when sticky
     top: 0;
   }
 `;

--- a/stories/layout/Layout-stories.tsx
+++ b/stories/layout/Layout-stories.tsx
@@ -21,6 +21,7 @@
 import styled from '@emotion/styled';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
+  BadgeSeverity,
   Button,
   cssVar,
   DropdownMenu,
@@ -37,6 +38,7 @@ import {
   LinkStandalone,
   LogoSonarQubeServer,
   Text,
+  TextInput,
 } from '../../src';
 import { AsideSize } from '../../src/components/layout/LayoutTypes';
 import { PageHeaderScrollBehavior } from '../../src/components/layout/header/common/HeaderTypes';
@@ -167,6 +169,20 @@ export const Default: Story = {
               Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
               mollit anim id est laborum.
             </p>
+            <StackingTestArea>
+              <TextInput label="Input (no z-index)" />
+              <HighZIndexBox />
+              <IsolatedBox />
+              <TransformBox />
+              <BadgeSeverity
+                ariaLabel="Badge (no z-index)"
+                quality="Badge (no z-index)"
+                severity="critical"
+              />
+              <DropdownMenu items={<DropdownMenu.ItemButton>An action</DropdownMenu.ItemButton>}>
+                <Button>Dropdown (portaled)</Button>
+              </DropdownMenu>
+            </StackingTestArea>
             <div
               style={{
                 display: 'flex',
@@ -352,6 +368,61 @@ const List = styled.ul`
     width: 100%;
   }
 `;
+
+const StackingTestArea = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+  margin-top: 32px;
+  margin-bottom: 32px;
+`;
+
+function HighZIndexBox() {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        zIndex: 9999,
+        padding: '12px 16px',
+        background: 'salmon',
+        borderRadius: '8px',
+        fontWeight: 'bold',
+      }}>
+      z-index: 9999
+    </div>
+  );
+}
+
+function IsolatedBox() {
+  return (
+    <div
+      style={{
+        isolation: 'isolate',
+        padding: '12px 16px',
+        background: 'lightblue',
+        borderRadius: '8px',
+      }}>
+      <div style={{ position: 'relative', zIndex: 9999 }}>
+        isolation: isolate (child z-index: 9999)
+      </div>
+    </div>
+  );
+}
+
+function TransformBox() {
+  return (
+    <div
+      style={{
+        transform: 'translateY(0)',
+        padding: '12px 16px',
+        background: 'lightgreen',
+        borderRadius: '8px',
+      }}>
+      <div style={{ position: 'relative', zIndex: 9999 }}>transform (child z-index: 9999)</div>
+    </div>
+  );
+}
 
 function getRandomColor() {
   return `hsl(${Math.random() * 360}, 100%, 75%)`;


### PR DESCRIPTION
Before:
<img width="1612" height="330" alt="image" src="https://github.com/user-attachments/assets/eba0fa71-bd32-47d7-a034-5502ec360446" />

After:
<img width="1612" height="330" alt="image" src="https://github.com/user-attachments/assets/69b160b5-84ec-4aca-aef2-758c413a56fd" />


Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
