### PR TITLE
ECHOES-1311 Pass brand value to build step in unified dogfooding workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: sonar-s-public
+    runs-on: sonar-s
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   shadow-scans:
-    runs-on: sonar-s-public
+    runs-on: sonar-s
     name: Build and run shadow scans
     permissions:
       id-token: write
@@ -20,6 +20,8 @@ jobs:
       - uses: SonarSource/ci-github-actions/build-yarn@v1
         with:
           run-shadow-scans: true
+        env:
+          DESIGN_TOKEN_BRAND: Brand-A
 
       - name: Run IRIS
         uses: SonarSource/unified-dogfooding-actions/run-iris@v1


### PR DESCRIPTION
The build step in the unified dofgooding workflow is missing the now-mandatory brand value.
Also, the sonar-s-public runners have been deprecated in favor of sonar-s, which can now handle public repositories.

A run of the dogfooding workflow on this PR's branch shows that it works: https://github.com/SonarSource/echoes-react/actions/runs/25716453852