### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestClosed_job:
     name: Pull Request Closed
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           promote-pull-request: true
 
   slack-notifications:
-    runs-on: github-ubuntu-latest-s # Public GH runner is required, runners starting with sonar-* do not support this action
+    runs-on: warp-custom-ubuntu-24-04 # Public GH runner is required, runners starting with sonar-* do not support this action
     if: failure() && (contains(fromJSON('["main", "master"]'), github.ref_name) || startsWith(github.ref_name, 'branch-'))
     needs: [ build, promote ]
     permissions:

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   slack-notifications:
-    runs-on: github-ubuntu-latest-s # Public GH runner is required, runners starting with sonar-* do not support this action
+    runs-on: warp-custom-ubuntu-24-04 # Public GH runner is required, runners starting with sonar-* do not support this action
     if: failure()
     needs: [ releasability-status ]
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
 
   slack-notifications:
-    runs-on: github-ubuntu-latest-s # Public GH runner is required, runners starting with sonar-* do not support this action
+    runs-on: warp-custom-ubuntu-24-04 # Public GH runner is required, runners starting with sonar-* do not support this action
     needs: [ release ]
     permissions:
       id-token: write

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -34,7 +34,7 @@ jobs:
           shadow2_platform: "SQC-US"
 
   slack-notifications:
-    runs-on: github-ubuntu-latest-s # Public GH runner is required, runners starting with sonar-* do not support this action
+    runs-on: warp-custom-ubuntu-24-04 # Public GH runner is required, runners starting with sonar-* do not support this action
     if: failure()
     needs: [ shadow-scans ]
     permissions:


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/build.yml`
- `.github/workflows/PullRequestClosed.yml`
- `.github/workflows/PullRequestCreated.yml`
- `.github/workflows/releasability.yml`
- `.github/workflows/release.yml`
- `.github/workflows/unified-dogfooding.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
