### PR TITLE
ECHOES-1339 Document stable-id toast updates as a supported pattern

### DIFF
--- a/src/utils/__tests__/toasts-test.tsx
+++ b/src/utils/__tests__/toasts-test.tsx
@@ -219,3 +219,30 @@ describe('toast utility - dismissal and interaction', () => {
     jest.useRealTimers();
   });
 });
+
+describe('toast utility - stable id updates', () => {
+  afterEach(() => {
+    sonnerToast.dismiss();
+  });
+
+  it('should replace an existing toast when the same stable id is reused', async () => {
+    render(<div />);
+
+    toast.info({
+      description: 'Synchronizing repository settings...',
+      id: 'repository-sync',
+    });
+
+    expect(await screen.findByText('Synchronizing repository settings...')).toBeInTheDocument();
+
+    toast.success({
+      description: 'Repository settings synchronized.',
+      id: 'repository-sync',
+      title: 'Sync complete',
+    });
+
+    expect(await screen.findByText('Repository settings synchronized.')).toBeInTheDocument();
+    expect(screen.getByText('Sync complete')).toBeInTheDocument();
+    expect(screen.queryByText('Synchronizing repository settings...')).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/toasts.tsx
+++ b/src/utils/toasts.tsx
@@ -50,9 +50,10 @@ export enum ToastDuration {
 
 export interface ToastParams extends Omit<ToastProps, 'id'> {
   /**
-   * Optional unique identifier for the toast. If not provided, one will be generated automatically.
-   * This ID is used to manage the toast's lifecycle, such as dismissing it manually or modifying it.
-   * Using the same ID for multiple toast call will update the existing toast instead of creating a new one.
+   * Optional stable identifier for the toast. If not provided, one will be generated automatically.
+   * This ID is used to manage the toast's lifecycle, such as dismissing it manually or updating it.
+   * Reusing the same `id` is the supported way to intentionally replace or update the existing
+   * toast instead of creating a second one.
    */
   id?: ToastId;
   /**
@@ -158,10 +159,11 @@ type ToastFn = {
  * @param ref - Optional React ref for the toast element
  * @returns The unique identifier of the created toast
  *
- * **Updating a toast**
+ * **Updating a toast with a stable id**
  *
- * It's possible to update an existing toast with new texts, new variety, etc, by just calling the
- * `toast` function again with the same ID.
+ * Reuse a stable `id` when a later toast call should replace or update an existing visible toast.
+ * Calling `toast` or one of the variety shortcuts again with that `id` updates the existing toast
+ * instead of creating a second one.
  *
  * **Important Rules**
  *
@@ -182,6 +184,19 @@ type ToastFn = {
  * toast.error({ description: "Failed to save file" });
  * toast.info({ description: "New update available" });
  * toast.warning({ description: "Storage space is low" });
+ *
+ * // Update an existing toast by reusing a stable ID
+ * const syncToastId = "repository-sync";
+ *
+ * toast.info({
+ *   id: syncToastId,
+ *   description: "Synchronizing repository settings..."
+ * });
+ *
+ * toast.success({
+ *   id: syncToastId,
+ *   description: "Repository settings synchronized."
+ * });
  *
  * // With actions
  * toast.success({

--- a/stories/Toast-stories.tsx
+++ b/stories/Toast-stories.tsx
@@ -30,7 +30,11 @@ const meta: Meta<ToastParams> = {
   title: 'Echoes/Toast',
   argTypes: {
     ...toDisabledControlArgType('actions'),
-    ...toTextControlArgTypes('id', 'title', 'description'),
+    ...toTextControlArgTypes('title', 'description'),
+    id: {
+      control: { type: 'text' },
+      description: 'Reuse a stable id to replace or update an existing toast intentionally.',
+    },
     variety: {
       control: { type: 'select' },
       table: {
@@ -112,6 +116,7 @@ export const Shortcuts: Story = {
   args: {},
   render: (args) => {
     const { description = 'This is a success toast message', ...restArgs } = args;
+
     return (
       <>
         <span>The toast function provide shortcuts for each variety:</span>
@@ -133,6 +138,49 @@ toast.error({ description: 'Error toast message' });`}
           {'Show many'}
         </Button>
       </>
+    );
+  },
+};
+
+export const StableIdUpdates: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reuse a stable `id` when a later toast call should replace an existing visible toast. The second toast call updates the first one instead of creating another toast.',
+      },
+    },
+  },
+  render: (args) => {
+    const {
+      description = 'Repository settings synchronized.',
+      id = 'repository-sync',
+      title = 'Sync complete',
+      ...restArgs
+    } = args;
+
+    return (
+      <Button
+        onClick={() => {
+          toast.info({
+            description: 'Synchronizing repository settings...',
+            id,
+            title: 'Sync in progress',
+            ...restArgs,
+          });
+
+          globalThis.setTimeout(() => {
+            toast.success({
+              description,
+              id,
+              title,
+              ...restArgs,
+            });
+          }, 1000);
+        }}>
+        Show stable-id update
+      </Button>
     );
   },
 };


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation:**
  - Updated `ToastParams` JSDoc to define the stable `id` pattern for toast updates.
  - Enhanced `toast` function documentation with a clear example of reusing a stable ID.
- **Storybook:**
  - Added `StableIdUpdates` story demonstrating the toast replacement pattern.
  - Added `id` control to the `Toast` story for testing stable ID behavior.
- **Testing:**
  - Added a new test suite in `toasts-test.tsx` to verify that reusing an ID updates the existing toast.


<sub>This will update automatically on new commits.</sub>