### PR TITLE
ECHOES-1366 Fix LoadingContainer display

### DIFF
--- a/i18n/keys.json
+++ b/i18n/keys.json
@@ -108,6 +108,22 @@
     "defaultMessage": "(opens in new tab)",
     "description": "Screen reader-only text to indicate that the link will open in a new tab"
   },
+  "page_content.default_loaded_message": {
+    "defaultMessage": "Page content loaded",
+    "description": "Default message to be announced by screen readers when the page content is loaded"
+  },
+  "page_content.default_loading_message": {
+    "defaultMessage": "Loading page content",
+    "description": "Default message to be announced by screen readers when the page content is loading"
+  },
+  "page_grid.default_loaded_message": {
+    "defaultMessage": "Page loaded",
+    "description": "Default message to be announced by screen readers when the page is loaded"
+  },
+  "page_grid.default_loading_message": {
+    "defaultMessage": "Loading page",
+    "description": "Default message to be announced by screen readers when the page is loading"
+  },
   "pagination.next": {
     "defaultMessage": "Next",
     "description": "Label for the pagination button that takes you to the next page"

--- a/i18n/keys.json
+++ b/i18n/keys.json
@@ -124,6 +124,14 @@
     "defaultMessage": "Loading page",
     "description": "Default message to be announced by screen readers when the page is loading"
   },
+  "page_header.default_loaded_message": {
+    "defaultMessage": "Page header loaded",
+    "description": "Default message to be announced by screen readers when the page header is loaded"
+  },
+  "page_header.default_loading_message": {
+    "defaultMessage": "Loading page header",
+    "description": "Default message to be announced by screen readers when the page header is loading"
+  },
   "pagination.next": {
     "defaultMessage": "Next",
     "description": "Label for the pagination button that takes you to the next page"

--- a/src/common/components/LoadingStateProvider.tsx
+++ b/src/common/components/LoadingStateProvider.tsx
@@ -1,0 +1,38 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { ReactNode, useMemo } from 'react';
+import { isDefined } from '~common/helpers/types';
+import { LoadingContext } from './LoadingContext';
+
+interface LoadingStateProviderProps {
+  children?: ReactNode;
+  isLoading?: boolean;
+}
+
+export function LoadingStateProvider({ children, isLoading }: Readonly<LoadingStateProviderProps>) {
+  const loadingContextValue = useMemo(() => ({ isLoading: Boolean(isLoading) }), [isLoading]);
+
+  return isDefined(isLoading) ? (
+    <LoadingContext.Provider value={loadingContextValue}>{children}</LoadingContext.Provider>
+  ) : (
+    children
+  );
+}

--- a/src/common/components/ScreenReaderOnlyLoadingStatus.tsx
+++ b/src/common/components/ScreenReaderOnlyLoadingStatus.tsx
@@ -1,0 +1,69 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import styled from '@emotion/styled';
+import { FormattedMessage } from 'react-intl';
+import { screenReaderOnly } from '~common/helpers/styles';
+import { TextNode } from '~types/utils';
+
+export interface ScreenReaderOnlyLoadingStatusProps {
+  isLoading: boolean;
+  /**
+   * Specify what the screen reader announces once isLoading switches to `false`
+   *
+   * @defaultValue "Content loaded"
+   */
+  loadedMessage?: TextNode;
+  /**
+   * Specify what the screen reader announces when isLoading is `true`
+   *
+   * @defaultValue "Loading content"
+   */
+  loadingMessage?: TextNode;
+}
+
+export function ScreenReaderOnlyLoadingStatus(props: Readonly<ScreenReaderOnlyLoadingStatusProps>) {
+  const { isLoading, loadedMessage, loadingMessage } = props;
+
+  return (
+    <ScreenReaderOnlyLive aria-live="polite">
+      {isLoading
+        ? (loadingMessage ?? (
+            <FormattedMessage
+              defaultMessage="Loading content"
+              description="Default message to be announced by screen readers when the LoadingContainer is loading"
+              id="loading_container.default_loading_message"
+            />
+          ))
+        : (loadedMessage ?? (
+            <FormattedMessage
+              defaultMessage="Content loaded"
+              description="Default message to be announced by screen readers when the LoadingContainer has finished loading"
+              id="loading_container.default_loaded_message"
+            />
+          ))}
+    </ScreenReaderOnlyLive>
+  );
+}
+
+const ScreenReaderOnlyLive = styled.span`
+  ${screenReaderOnly};
+`;
+ScreenReaderOnlyLive.displayName = 'ScreenReaderOnlyLive';

--- a/src/components/layout/LayoutSlots.tsx
+++ b/src/components/layout/LayoutSlots.tsx
@@ -20,6 +20,11 @@
 
 import styled from '@emotion/styled';
 import { CSSProperties, forwardRef, PropsWithChildren } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { LoadingStateProvider } from '~common/components/LoadingStateProvider';
+import { ScreenReaderOnlyLoadingStatus } from '~common/components/ScreenReaderOnlyLoadingStatus';
+import { isDefined } from '~common/helpers/types';
+import { TextNode } from '~types/utils';
 import { cssVar } from '~utils/design-tokens';
 import { AsideSize, ContentGridArea, GlobalGridArea, PageGridArea, PageWidth } from './LayoutTypes';
 
@@ -92,15 +97,66 @@ StyledAsideLeft.displayName = 'StyledAside';
 
 export interface PageGridProps {
   className?: string;
+  /**
+   * Setting this prop will make this component behave like a LoadingContainer.
+   * It will provide a LoadingContext that LoadingSkeletons can consume (automatically),
+   * and deal with screen readers.
+   * Customize the accessible status messages by specifying `loadedMessage` and `loadingMessage`.
+   */
+  isLoading?: boolean;
+  /**
+   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * @defaultValue Page loaded
+   */
+  loadedMessage?: TextNode;
+  /**
+   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * @defaultValue Loading page
+   */
+  loadingMessage?: TextNode;
   width?: `${PageWidth}`;
 }
 
 export const PageGrid = forwardRef<HTMLDivElement, PropsWithChildren<PageGridProps>>(
   (props, ref) => {
-    const { children, width = 'default', ...restProps } = props;
+    const {
+      children,
+      isLoading,
+      loadedMessage,
+      loadingMessage,
+      width = 'default',
+      ...restProps
+    } = props;
+
     return (
-      <PageGridContainer {...restProps} ref={ref}>
-        <PageGridInner style={PAGE_WIDTH_STYLES[width]}>{children}</PageGridInner>
+      <PageGridContainer {...restProps} aria-busy={isLoading} ref={ref}>
+        <PageGridInner style={PAGE_WIDTH_STYLES[width]}>
+          <LoadingStateProvider isLoading={isLoading}>{children}</LoadingStateProvider>
+        </PageGridInner>
+
+        {isDefined(isLoading) && (
+          <ScreenReaderOnlyLoadingStatus
+            isLoading={isLoading}
+            loadedMessage={
+              loadedMessage ?? (
+                <FormattedMessage
+                  defaultMessage="Page loaded"
+                  description="Default message to be announced by screen readers when the page is loaded"
+                  id="page_grid.default_loaded_message"
+                />
+              )
+            }
+            loadingMessage={
+              loadingMessage ?? (
+                <FormattedMessage
+                  defaultMessage="Loading page"
+                  description="Default message to be announced by screen readers when the page is loading"
+                  id="page_grid.default_loading_message"
+                />
+              )
+            }
+          />
+        )}
       </PageGridContainer>
     );
   },
@@ -136,13 +192,73 @@ const PAGE_WIDTH_STYLES: Record<PageWidth, CSSProperties> = {
   [PageWidth.fluid]: {},
 };
 
-export const PageContent = styled.main`
+export interface PageContentProps {
+  className?: string;
+  /**
+   * Setting this prop will make this component behave like a LoadingContainer.
+   * It will provide a LoadingContext that LoadingSkeletons can consume (automatically),
+   * and deal with screen readers.
+   * Customize the accessible status messages by specifying `loadedMessage` and `loadingMessage`.
+   */
+  isLoading?: boolean;
+  /**
+   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * @defaultValue Page content loaded
+   */
+  loadedMessage?: TextNode;
+  /**
+   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * @defaultValue Loading page content
+   */
+  loadingMessage?: TextNode;
+}
+
+export const PageContent = forwardRef<HTMLElement, PropsWithChildren<PageContentProps>>(
+  (props, ref) => {
+    const { children, isLoading, loadedMessage, loadingMessage, ...restProps } = props;
+
+    return (
+      <>
+        <StyledPageContent {...restProps} aria-busy={isLoading} ref={ref}>
+          <LoadingStateProvider isLoading={isLoading}>{children}</LoadingStateProvider>
+        </StyledPageContent>
+
+        {isDefined(isLoading) && (
+          <ScreenReaderOnlyLoadingStatus
+            isLoading={isLoading}
+            loadedMessage={
+              loadedMessage ?? (
+                <FormattedMessage
+                  defaultMessage="Page content loaded"
+                  description="Default message to be announced by screen readers when the page content is loaded"
+                  id="page_content.default_loaded_message"
+                />
+              )
+            }
+            loadingMessage={
+              loadingMessage ?? (
+                <FormattedMessage
+                  defaultMessage="Loading page content"
+                  description="Default message to be announced by screen readers when the page content is loading"
+                  id="page_content.default_loading_message"
+                />
+              )
+            }
+          />
+        )}
+      </>
+    );
+  },
+);
+PageContent.displayName = 'PageContent';
+
+const StyledPageContent = styled.main`
   grid-area: ${PageGridArea.main};
 
   padding: ${cssVar('dimension-space-300')};
   isolation: isolate; // Prevent content z-index values from escaping and overlapping a sticky PageHeader
 `;
-PageContent.displayName = 'PageContent';
+StyledPageContent.displayName = 'StyledPageContent';
 
 export const PageFooter = styled.footer`
   grid-area: ${PageGridArea.footer};

--- a/src/components/layout/LayoutSlots.tsx
+++ b/src/components/layout/LayoutSlots.tsx
@@ -19,7 +19,13 @@
  */
 
 import styled from '@emotion/styled';
-import { CSSProperties, forwardRef, PropsWithChildren } from 'react';
+import {
+  CSSProperties,
+  DetailedHTMLProps,
+  forwardRef,
+  HTMLAttributes,
+  PropsWithChildren,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 import { LoadingStateProvider } from '~common/components/LoadingStateProvider';
 import { ScreenReaderOnlyLoadingStatus } from '~common/components/ScreenReaderOnlyLoadingStatus';
@@ -213,43 +219,44 @@ export interface PageContentProps {
   loadingMessage?: TextNode;
 }
 
-export const PageContent = forwardRef<HTMLElement, PropsWithChildren<PageContentProps>>(
-  (props, ref) => {
-    const { children, isLoading, loadedMessage, loadingMessage, ...restProps } = props;
+export const PageContent = forwardRef<
+  HTMLElement,
+  PropsWithChildren<PageContentProps & DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>>
+>((props, ref) => {
+  const { children, isLoading, loadedMessage, loadingMessage, ...restProps } = props;
 
-    return (
-      <>
-        <StyledPageContent {...restProps} aria-busy={isLoading} ref={ref}>
-          <LoadingStateProvider isLoading={isLoading}>{children}</LoadingStateProvider>
-        </StyledPageContent>
+  return (
+    <>
+      <StyledPageContent {...restProps} aria-busy={isLoading} ref={ref}>
+        <LoadingStateProvider isLoading={isLoading}>{children}</LoadingStateProvider>
+      </StyledPageContent>
 
-        {isDefined(isLoading) && (
-          <ScreenReaderOnlyLoadingStatus
-            isLoading={isLoading}
-            loadedMessage={
-              loadedMessage ?? (
-                <FormattedMessage
-                  defaultMessage="Page content loaded"
-                  description="Default message to be announced by screen readers when the page content is loaded"
-                  id="page_content.default_loaded_message"
-                />
-              )
-            }
-            loadingMessage={
-              loadingMessage ?? (
-                <FormattedMessage
-                  defaultMessage="Loading page content"
-                  description="Default message to be announced by screen readers when the page content is loading"
-                  id="page_content.default_loading_message"
-                />
-              )
-            }
-          />
-        )}
-      </>
-    );
-  },
-);
+      {isDefined(isLoading) && (
+        <ScreenReaderOnlyLoadingStatus
+          isLoading={isLoading}
+          loadedMessage={
+            loadedMessage ?? (
+              <FormattedMessage
+                defaultMessage="Page content loaded"
+                description="Default message to be announced by screen readers when the page content is loaded"
+                id="page_content.default_loaded_message"
+              />
+            )
+          }
+          loadingMessage={
+            loadingMessage ?? (
+              <FormattedMessage
+                defaultMessage="Loading page content"
+                description="Default message to be announced by screen readers when the page content is loading"
+                id="page_content.default_loading_message"
+              />
+            )
+          }
+        />
+      )}
+    </>
+  );
+});
 PageContent.displayName = 'PageContent';
 
 const StyledPageContent = styled.main`

--- a/src/components/layout/LayoutSlots.tsx
+++ b/src/components/layout/LayoutSlots.tsx
@@ -111,12 +111,12 @@ export interface PageGridProps {
    */
   isLoading?: boolean;
   /**
-   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * Allows you to customize the screen reader-only status message announced when `isLoading` is false.
    * @defaultValue Page loaded
    */
   loadedMessage?: TextNode;
   /**
-   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * Allows you to customize the screen reader-only status message announced when `isLoading` is true.
    * @defaultValue Loading page
    */
   loadingMessage?: TextNode;
@@ -135,10 +135,12 @@ export const PageGrid = forwardRef<HTMLDivElement, PropsWithChildren<PageGridPro
     } = props;
 
     return (
-      <PageGridContainer {...restProps} aria-busy={isLoading} ref={ref}>
-        <PageGridInner style={PAGE_WIDTH_STYLES[width]}>
-          <LoadingStateProvider isLoading={isLoading}>{children}</LoadingStateProvider>
-        </PageGridInner>
+      <>
+        <PageGridContainer {...restProps} aria-busy={isLoading} ref={ref}>
+          <PageGridInner style={PAGE_WIDTH_STYLES[width]}>
+            <LoadingStateProvider isLoading={isLoading}>{children}</LoadingStateProvider>
+          </PageGridInner>
+        </PageGridContainer>
 
         {isDefined(isLoading) && (
           <ScreenReaderOnlyLoadingStatus
@@ -163,7 +165,7 @@ export const PageGrid = forwardRef<HTMLDivElement, PropsWithChildren<PageGridPro
             }
           />
         )}
-      </PageGridContainer>
+      </>
     );
   },
 );
@@ -208,12 +210,12 @@ export interface PageContentProps {
    */
   isLoading?: boolean;
   /**
-   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * Allows you to customize the screen reader-only status message announced when `isLoading` is false.
    * @defaultValue Page content loaded
    */
   loadedMessage?: TextNode;
   /**
-   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * Allows you to customize the screen reader-only status message announced when `isLoading` is true.
    * @defaultValue Loading page content
    */
   loadingMessage?: TextNode;

--- a/src/components/layout/__tests__/LayoutSlots-test.tsx
+++ b/src/components/layout/__tests__/LayoutSlots-test.tsx
@@ -20,7 +20,7 @@
 
 import { screen } from '@testing-library/react';
 import { render } from '~common/helpers/test-utils';
-import { AsideLeft, PageGrid } from '../LayoutSlots';
+import { AsideLeft, PageContent, PageGrid } from '../LayoutSlots';
 import { AsideSize, PageWidth } from '../LayoutTypes';
 
 describe('PageGrid', () => {
@@ -39,6 +39,57 @@ describe('PageGrid', () => {
     expect(screen.getByText('content')).not.toHaveStyle({
       maxWidth: 'var(--echoes-layout-sizes-max-width-default)',
     });
+  });
+
+  it.each([
+    ['loading', { isLoading: true }, 'true', 'Loading page'],
+    ['not loading', { isLoading: false }, 'false', 'Page loaded'],
+    [
+      'loading (custom message)',
+      { isLoading: true, loadingMessage: 'Fetching data' },
+      'true',
+      'Fetching data',
+    ],
+    [
+      'not loading (custom message)',
+      { isLoading: false, loadedMessage: 'All done' },
+      'false',
+      'All done',
+    ],
+  ])('should render correctly when %s', async (_, args, ariaBusy, expectedText) => {
+    const { container } = render(<PageGrid {...args}>content</PageGrid>);
+
+    await expect(container).toHaveNoA11yViolations();
+
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(container.firstChild).toHaveAttribute('aria-busy', ariaBusy);
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
+  });
+});
+
+describe('PageContent', () => {
+  it.each([
+    ['loading', { isLoading: true }, 'true', 'Loading page content'],
+    ['not loading', { isLoading: false }, 'false', 'Page content loaded'],
+    [
+      'loading (custom message)',
+      { isLoading: true, loadingMessage: 'Fetching data' },
+      'true',
+      'Fetching data',
+    ],
+    [
+      'not loading (custom message)',
+      { isLoading: false, loadedMessage: 'All done' },
+      'false',
+      'All done',
+    ],
+  ])('should render correctly when %s', async (_, args, ariaBusy, expectedText) => {
+    const { container } = render(<PageContent {...args}>content</PageContent>);
+
+    await expect(container).toHaveNoA11yViolations();
+
+    expect(screen.getByRole('main')).toHaveAttribute('aria-busy', ariaBusy);
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
   });
 });
 

--- a/src/components/layout/header/common/HeaderBase.tsx
+++ b/src/components/layout/header/common/HeaderBase.tsx
@@ -20,6 +20,10 @@
 
 import styled from '@emotion/styled';
 import { CSSProperties, forwardRef } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { LoadingStateProvider } from '~common/components/LoadingStateProvider';
+import { ScreenReaderOnlyLoadingStatus } from '~common/components/ScreenReaderOnlyLoadingStatus';
+import { isDefined } from '~common/helpers/types';
 import { cssVar } from '~utils/design-tokens';
 import {
   StyledDivider,
@@ -46,6 +50,9 @@ const HeaderBase = forwardRef<HTMLDivElement, HeaderProps & InternalProps>((prop
     description,
     hasDivider,
     hasFullWidthNav,
+    isLoading,
+    loadedMessage,
+    loadingMessage,
     metadata,
     navigation,
     title,
@@ -53,33 +60,61 @@ const HeaderBase = forwardRef<HTMLDivElement, HeaderProps & InternalProps>((prop
   } = props;
 
   return (
-    <header ref={ref} {...rest}>
-      {callout && <StyledPageHeaderCallout>{callout}</StyledPageHeaderCallout>}
+    <>
+      <header aria-busy={isLoading} ref={ref} {...rest}>
+        <LoadingStateProvider isLoading={isLoading}>
+          {callout && <StyledPageHeaderCallout>{callout}</StyledPageHeaderCallout>}
 
-      {breadcrumbs && <StyledPageHeaderBreadcrumbs>{breadcrumbs}</StyledPageHeaderBreadcrumbs>}
+          {breadcrumbs && <StyledPageHeaderBreadcrumbs>{breadcrumbs}</StyledPageHeaderBreadcrumbs>}
 
-      <StyledPageHeaderMain>
-        {title}
+          <StyledPageHeaderMain>
+            {title}
 
-        {metadata}
+            {metadata}
 
-        {description}
-      </StyledPageHeaderMain>
+            {description}
+          </StyledPageHeaderMain>
 
-      {actions && (
-        <StyledPageHeaderActions style={actionsStyles}>{actions}</StyledPageHeaderActions>
+          {actions && (
+            <StyledPageHeaderActions style={actionsStyles}>{actions}</StyledPageHeaderActions>
+          )}
+
+          {navigation && (
+            <>
+              <StyledPageHeaderBottom>{navigation}</StyledPageHeaderBottom>
+
+              {hasDivider && <StyledDividerWithOverlap />}
+            </>
+          )}
+
+          {hasDivider && !navigation && <StyledDivider />}
+        </LoadingStateProvider>
+      </header>
+
+      {isDefined(isLoading) && (
+        <ScreenReaderOnlyLoadingStatus
+          isLoading={isLoading}
+          loadedMessage={
+            loadedMessage ?? (
+              <FormattedMessage
+                defaultMessage="Page header loaded"
+                description="Default message to be announced by screen readers when the page header is loaded"
+                id="page_header.default_loaded_message"
+              />
+            )
+          }
+          loadingMessage={
+            loadingMessage ?? (
+              <FormattedMessage
+                defaultMessage="Loading page header"
+                description="Default message to be announced by screen readers when the page header is loading"
+                id="page_header.default_loading_message"
+              />
+            )
+          }
+        />
       )}
-
-      {navigation && (
-        <>
-          <StyledPageHeaderBottom>{navigation}</StyledPageHeaderBottom>
-
-          {hasDivider && <StyledDividerWithOverlap />}
-        </>
-      )}
-
-      {hasDivider && !navigation && <StyledDivider />}
-    </header>
+    </>
   );
 });
 HeaderBase.displayName = 'HeaderBase';

--- a/src/components/layout/header/common/HeaderTypes.ts
+++ b/src/components/layout/header/common/HeaderTypes.ts
@@ -19,6 +19,7 @@
  */
 
 import { ReactNode } from 'react';
+import { TextNode } from '~types/utils';
 
 export enum PageHeaderArea {
   breadcrumbs = 'breadcrumbs',
@@ -109,6 +110,23 @@ export interface HeaderProps {
    * @defaultValue false
    */
   hasDivider?: boolean;
+  /**
+   * Setting this prop will make this component behave like a LoadingContainer.
+   * It will provide a LoadingContext that LoadingSkeletons can consume (automatically),
+   * and deal with screen readers.
+   * Customize the accessible status messages by specifying `loadedMessage` and `loadingMessage`.
+   */
+  isLoading?: boolean;
+  /**
+   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * @defaultValue Page header loaded
+   */
+  loadedMessage?: TextNode;
+  /**
+   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * @defaultValue Loading page header
+   */
+  loadingMessage?: TextNode;
   /**
    * Metadata elements to display below the title. Use <PageHeader.Metadata> to wrap them.
    */

--- a/src/components/layout/header/common/HeaderTypes.ts
+++ b/src/components/layout/header/common/HeaderTypes.ts
@@ -118,12 +118,12 @@ export interface HeaderProps {
    */
   isLoading?: boolean;
   /**
-   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * Allows you to customize the screen reader-only status message announced when `isLoading` is false.
    * @defaultValue Page header loaded
    */
   loadedMessage?: TextNode;
   /**
-   * Allows you to customize the screen reader-only status message when `isLoading` is defined.
+   * Allows you to customize the screen reader-only status message announced when `isLoading` is true.
    * @defaultValue Loading page header
    */
   loadingMessage?: TextNode;

--- a/src/components/layout/header/content-header/__tests__/ContentHeader-test.tsx
+++ b/src/components/layout/header/content-header/__tests__/ContentHeader-test.tsx
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { screen } from '@testing-library/react';
 import { renderWithMemoryRouter } from '~common/helpers/test-utils';
 import { ContentHeader } from '../..';
 
@@ -27,4 +28,35 @@ it('should display a ContentHeader properly', async () => {
   );
 
   await expect(container).toHaveNoA11yViolations();
+});
+
+describe('isLoading', () => {
+  it.each([
+    ['loading', { isLoading: true }, 'true', 'Loading page header'],
+    ['not loading', { isLoading: false }, 'false', 'Page header loaded'],
+    [
+      'loading (custom message)',
+      { isLoading: true, loadingMessage: 'Fetching data' },
+      'true',
+      'Fetching data',
+    ],
+    [
+      'not loading (custom message)',
+      { isLoading: false, loadedMessage: 'All done' },
+      'false',
+      'All done',
+    ],
+  ])('should render correctly when %s', async (_, args, ariaBusy, expectedText) => {
+    const { container } = renderWithMemoryRouter(
+      <ContentHeader
+        title={<ContentHeader.Title>Awesome content header</ContentHeader.Title>}
+        {...args}
+      />,
+    );
+
+    await expect(container).toHaveNoA11yViolations();
+
+    expect(screen.getByRole('banner')).toHaveAttribute('aria-busy', ariaBusy);
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
+  });
 });

--- a/src/components/layout/header/page-header/__tests__/PageHeader-test.tsx
+++ b/src/components/layout/header/page-header/__tests__/PageHeader-test.tsx
@@ -63,6 +63,32 @@ it('should display a minimal PageHeader properly', () => {
   expect(screen.getByText('Page title')).toBeInTheDocument();
 });
 
+describe('isLoading', () => {
+  it.each([
+    ['loading', { isLoading: true }, 'true', 'Loading page header'],
+    ['not loading', { isLoading: false }, 'false', 'Page header loaded'],
+    [
+      'loading (custom message)',
+      { isLoading: true, loadingMessage: 'Fetching data' },
+      'true',
+      'Fetching data',
+    ],
+    [
+      'not loading (custom message)',
+      { isLoading: false, loadedMessage: 'All done' },
+      'false',
+      'All done',
+    ],
+  ])('should render correctly when %s', async (_, args, ariaBusy, expectedText) => {
+    const { container } = setup(args);
+
+    await expect(container).toHaveNoA11yViolations();
+
+    expect(screen.getByRole('banner')).toHaveAttribute('aria-busy', ariaBusy);
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
+  });
+});
+
 describe('scroll behavior', () => {
   it.each([
     [PageHeaderScrollBehavior.collapse, false, 'sticky'],

--- a/src/components/loading-container/LoadingContainer.tsx
+++ b/src/components/loading-container/LoadingContainer.tsx
@@ -18,11 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import styled from '@emotion/styled';
 import { PropsWithChildren, useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { LoadingContext } from '~common/components/LoadingContext';
-import { screenReaderOnly } from '~common/helpers/styles';
+import { ScreenReaderOnlyLoadingStatus } from '~common/components/ScreenReaderOnlyLoadingStatus';
 
 export interface LoadingContainerProps {
   className?: string;
@@ -59,34 +57,15 @@ export function LoadingContainer(props: PropsWithChildren<LoadingContainerProps>
 
   return (
     <>
-      <LoadingContext.Provider value={loadingContextValue}>
-        <div aria-busy={isLoading} className={className}>
-          {children}
-        </div>
-      </LoadingContext.Provider>
+      <div aria-busy={isLoading} className={className}>
+        <LoadingContext.Provider value={loadingContextValue}>{children}</LoadingContext.Provider>
+      </div>
 
-      <ScreenReaderOnlyLive aria-live="polite">
-        {isLoading
-          ? (loadingMessage ?? (
-              <FormattedMessage
-                defaultMessage="Loading content"
-                description="Default message to be announced by screen readers when the LoadingContainer is loading"
-                id="loading_container.default_loading_message"
-              />
-            ))
-          : (loadedMessage ?? (
-              <FormattedMessage
-                defaultMessage="Content loaded"
-                description="Default message to be announced by screen readers when the LoadingContainer has finished loading"
-                id="loading_container.default_loaded_message"
-              />
-            ))}
-      </ScreenReaderOnlyLive>
+      <ScreenReaderOnlyLoadingStatus
+        isLoading={isLoading}
+        loadedMessage={loadedMessage}
+        loadingMessage={loadingMessage}
+      />
     </>
   );
 }
-
-const ScreenReaderOnlyLive = styled.span`
-  ${screenReaderOnly};
-`;
-ScreenReaderOnlyLive.displayName = 'ScreenReaderOnlyLive';

--- a/src/components/loading-container/LoadingContainer.tsx
+++ b/src/components/loading-container/LoadingContainer.tsx
@@ -25,6 +25,7 @@ import { LoadingContext } from '~common/components/LoadingContext';
 import { screenReaderOnly } from '~common/helpers/styles';
 
 export interface LoadingContainerProps {
+  className?: string;
   isLoading: boolean;
   /**
    * Specify what the screen reader announces once isLoading switches to `false`
@@ -52,14 +53,16 @@ export interface LoadingContainerProps {
  * Both status messages can be specified.
  */
 export function LoadingContainer(props: PropsWithChildren<LoadingContainerProps>) {
-  const { children, isLoading, loadedMessage, loadingMessage } = props;
+  const { className, children, isLoading, loadedMessage, loadingMessage } = props;
 
   const loadingContextValue = useMemo(() => ({ isLoading }), [isLoading]);
 
   return (
     <>
       <LoadingContext.Provider value={loadingContextValue}>
-        <div aria-busy={isLoading}>{children}</div>
+        <div aria-busy={isLoading} className={className}>
+          {children}
+        </div>
       </LoadingContext.Provider>
 
       <ScreenReaderOnlyLive aria-live="polite">
@@ -83,7 +86,7 @@ export function LoadingContainer(props: PropsWithChildren<LoadingContainerProps>
   );
 }
 
-export const ScreenReaderOnlyLive = styled.span`
+const ScreenReaderOnlyLive = styled.span`
   ${screenReaderOnly};
 `;
 ScreenReaderOnlyLive.displayName = 'ScreenReaderOnlyLive';

--- a/src/components/loading-skeleton/LoadingSkeletonStyles.tsx
+++ b/src/components/loading-skeleton/LoadingSkeletonStyles.tsx
@@ -34,7 +34,7 @@ const shimmer = keyframes`
 `;
 
 const LoadingSkeletonBaseStyle = styled.div`
-  background-color: ${cssVar('color-surface-hover')};
+  background-color: ${cssVar('color-background-neutral-subtle-default')};
 
   border-radius: ${cssVar('border-radius-200')};
 

--- a/stories/layout/Layout-stories.tsx
+++ b/stories/layout/Layout-stories.tsx
@@ -36,6 +36,7 @@ import {
   IconSecurityFinding,
   Layout,
   LinkStandalone,
+  LoadingSkeleton,
   LogoSonarQubeServer,
   Text,
   TextInput,
@@ -144,6 +145,8 @@ export const Default: Story = {
     aside: AsideSize.medium,
     banner: 'none',
     contentHeader: false,
+    pageLoading: true,
+    pageContentLoading: true,
     pageHeader: true,
     pageHeaderScrollBehavior: PageHeaderScrollBehavior.scroll,
     pageWidth: 'default',
@@ -158,16 +161,18 @@ export const Default: Story = {
         {args.contentHeader}
         {args.aside}
 
-        <Layout.PageGrid width={args.pageWidth}>
+        <Layout.PageGrid isLoading={args.pageLoading} width={args.pageWidth}>
           {args.pageHeader(args.pageHeaderScrollBehavior)}
-          <Layout.PageContent>
+          <Layout.PageContent isLoading={args.pageContentLoading}>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-              exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-              dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-              mollit anim id est laborum.
+              <LoadingSkeleton variety="paragraph">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+                irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum.
+              </LoadingSkeleton>
             </p>
             <StackingTestArea>
               <TextInput label="Input (no z-index)" />


### PR DESCRIPTION
----
## Summary by Gitar

- **Component refactoring:**
  - Introduced `ScreenReaderOnlyLoadingStatus` to centralize accessible loading announcements.
  - Added `LoadingStateProvider` to wrap child components with `LoadingContext` conditionally.
  - Updated `LoadingContainer` to utilize these new utilities and support `className` forwarding.
- **Layout improvements:**
  - Added `isLoading` support to `PageGrid`, `PageContent`, and `HeaderBase`, enabling automated screen reader announcements and `LoadingContext` for nested `LoadingSkeleton` components.
- **Testing and localization:**
  - Added comprehensive accessibility tests for `PageGrid` and `PageContent` loading states.
  - Added new `i18n` keys for default screen reader messages in `PageGrid`, `PageContent`, and `HeaderBase`.
- **Storybook updates:**
  - Updated `Layout-stories` to include `LoadingSkeleton` and demonstrate the new `isLoading` states for grid, content, and header components.


<sub>This will update automatically on new commits.</sub>