### PR TITLE
ECHOES-1367 Jira workflows: Add rootly and PREQ component

### DIFF
--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -21,9 +21,12 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
+            development/kv/data/rootly ro-api-key | ROOTLY_TOKEN;
       - uses: sonarsource/gh-action-lt-backlog/PullRequestCreated@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          rootly-token: ${{ fromJSON(steps.secrets.outputs.vault).ROOTLY_TOKEN }}
           jira-project: ECHOES
+          team-review-component: Echoes

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -21,8 +21,11 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
+            development/kv/data/rootly ro-api-key | ROOTLY_TOKEN;
       - uses: sonarsource/gh-action-lt-backlog/RequestReview@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token:   ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          rootly-token: ${{ fromJSON(steps.secrets.outputs.vault).ROOTLY_TOKEN }}
+          team-review-component: Echoes


### PR DESCRIPTION
Post-edit: The fact that PREQ-6342 was created with component and assignee from Rootly proves that it works.

It took 3 re-runs because of 
<img width="1135" height="544" alt="image" src="https://github.com/user-attachments/assets/5a3934c9-6b1f-43cc-bb5a-6941fed10751" />


----
## Summary by Gitar

- **CI/CD configuration:**
  - Added `ROOTLY_TOKEN` secret retrieval in `.github/workflows/PullRequestCreated.yml` and `RequestReview.yml`.
  - Configured `team-review-component` as `Echoes` in both workflow files to support the PREQ component integration.

<sub>This will update automatically on new commits.</sub>