### PR TITLE
ECHOES-1337 ECHOES-1338 Align toast lifecycle defaults with notification guidelines

### DIFF
--- a/src/common/components/Toast.tsx
+++ b/src/common/components/Toast.tsx
@@ -79,8 +79,7 @@ export interface ToastProps {
   /**
    * Custom actions to display in the toast (optional). Receives the toast ID
    * and dismiss function as parameters. It should be either one or more Buttons or Links.
-   * If provided, the toast should also have the `isDismissable` prop set to true
-   * and its duration set to infinite.
+   * If provided, the toast should also have the `isDismissable` prop set to true.
    */
   actions?: ({ id, dismiss }: ToastActionsParams) => ReactNode;
   /**
@@ -94,7 +93,8 @@ export interface ToastProps {
   id: ToastId;
   /**
    * When true, displays a dismiss button allowing users to manually close the toast (optional).
-   * It must be set to true if the duration of the toast is set to infinite though.
+   * It must be set to true if the duration of the toast is set to infinite or if actions are
+   * provided.
    * The default is false.
    */
   isDismissable?: boolean;

--- a/src/components/echoes-provider/EchoesProvider.tsx
+++ b/src/components/echoes-provider/EchoesProvider.tsx
@@ -35,7 +35,7 @@ export interface EchoesProviderProps {
   /**
    * Maximum number of toast notifications visible simultaneously (optional).
    * When this limit is reached, older toasts will be automatically dismissed
-   * to make room for new ones. The default is 5.
+   * to make room for new ones. The default is 3.
    */
   toastsVisibleNb?: number;
   /**
@@ -88,7 +88,7 @@ export interface EchoesProviderProps {
  * ```
  */
 export function EchoesProvider(props: PropsWithChildren<EchoesProviderProps>) {
-  const { children, tooltipsDelayDuration, toastsClassName, toastsVisibleNb = 5 } = props;
+  const { children, tooltipsDelayDuration, toastsClassName, toastsVisibleNb = 3 } = props;
   const intl = useIntl();
   const [portalRef, setPortalRef] = useState<HTMLDivElement | null>(null);
 
@@ -136,7 +136,7 @@ EchoesProvider.displayName = 'EchoesProvider';
  * It doesn't prevent tests using Modals to work fine.
  */
 export function EchoesProviderForTests(props: PropsWithChildren<EchoesProviderProps>) {
-  const { children, tooltipsDelayDuration, toastsClassName, toastsVisibleNb = 5 } = props;
+  const { children, tooltipsDelayDuration, toastsClassName, toastsVisibleNb = 3 } = props;
   const intl = useIntl();
 
   return (

--- a/src/utils/__tests__/toasts-aggregation-ui-test.tsx
+++ b/src/utils/__tests__/toasts-aggregation-ui-test.tsx
@@ -40,7 +40,7 @@ const { resetToastTestState, trackToastId } = createToastTestState({
 describe('toast utility - automatic aggregation UI', () => {
   afterEach(resetToastTestState);
 
-  it('should aggregate repeated toasts without a title when the description and variety match', async () => {
+  it('should aggregate title-less toasts when description and variety match', async () => {
     render(<div />);
 
     trackToastId(toast.success(descriptionOnlyUploadCompleteToast));
@@ -55,7 +55,7 @@ describe('toast utility - automatic aggregation UI', () => {
     expect(screen.getByText(/^2$/)).toBeInTheDocument();
   });
 
-  it('should treat blank plain-text titles as absent when aggregating repeated toasts', async () => {
+  it('should treat blank plain-text titles as absent during aggregation', async () => {
     render(<div />);
 
     trackToastId(
@@ -75,7 +75,7 @@ describe('toast utility - automatic aggregation UI', () => {
     expect(screen.getByText(/^2$/)).toBeInTheDocument();
   });
 
-  it('should aggregate repeated toasts with the same plain-text title, description, and variety', async () => {
+  it('should aggregate repeated toasts when title, description, and variety match', async () => {
     render(<div />);
 
     trackToastId(toast.success(uploadCompleteToast));
@@ -150,7 +150,7 @@ describe('toast utility - automatic aggregation UI', () => {
     expect(await screen.findByText('File uploaded')).toBeInTheDocument();
 
     act(() => {
-      jest.advanceTimersByTime(8000);
+      jest.advanceTimersByTime(3000);
       jest.runOnlyPendingTimers();
     });
 
@@ -174,7 +174,7 @@ describe('toast utility - automatic aggregation UI', () => {
     expect(screen.queryByText('Shown 2 times')).not.toBeInTheDocument();
   });
 
-  it('should keep the aggregation story aggregating when Storybook injects lifecycle action args', async () => {
+  it('should keep the aggregation story working when Storybook adds lifecycle args', async () => {
     jest.useFakeTimers();
 
     const storyElement = AggregatedRepeatedToasts.render!(

--- a/src/utils/__tests__/toasts-test.tsx
+++ b/src/utils/__tests__/toasts-test.tsx
@@ -59,7 +59,6 @@ describe('toast utility - basic functionality', () => {
         title: 'Success title',
         description: SUCCESS_MESSAGE,
         id: 'custom-id',
-        duration: ToastDuration.Infinite,
         isDismissable: true,
         screenReaderPrefix: 'Toast prefix',
         actions,
@@ -164,7 +163,6 @@ describe('toast utility - dismissal and interaction', () => {
       toast({
         variety: ToastVariety.Success,
         description: actionToastMessage,
-        duration: ToastDuration.Infinite,
         isDismissable: true,
         actions: ({ dismiss }) => (
           <Button
@@ -192,6 +190,94 @@ describe('toast utility - dismissal and interaction', () => {
     expect(onAutoClose).not.toHaveBeenCalled();
   });
 
+  it('should dismiss a regular toast after the default medium duration', async () => {
+    jest.useFakeTimers();
+
+    const onAutoClose = jest.fn();
+    const onDismiss = jest.fn();
+    render(<div />);
+
+    trackToastId(
+      toast({
+        variety: ToastVariety.Info,
+        description: TEST_MESSAGE,
+        onAutoClose,
+        onDismiss,
+      }),
+    );
+
+    expect(await screen.findByText(TEST_MESSAGE)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(screen.getByText(TEST_MESSAGE)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+      jest.runOnlyPendingTimers();
+    });
+
+    act(() => {
+      // Sonner finalizes auto-dismiss on the next animation frame.
+      jest.advanceTimersToNextFrame();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(TEST_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    expect(onAutoClose).toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('should dismiss an action toast after the default long duration', async () => {
+    jest.useFakeTimers();
+
+    const onAutoClose = jest.fn();
+    const onDismiss = jest.fn();
+    render(<div />);
+
+    trackToastId(
+      toast({
+        variety: ToastVariety.Success,
+        description: SUCCESS_MESSAGE,
+        isDismissable: true,
+        actions: () => <Button>Open report</Button>,
+        onAutoClose,
+        onDismiss,
+      }),
+    );
+
+    expect(await screen.findByText(SUCCESS_MESSAGE)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open report' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss toast' })).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(7000);
+    });
+
+    expect(screen.getByText(SUCCESS_MESSAGE)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+      jest.runOnlyPendingTimers();
+    });
+
+    act(() => {
+      // Sonner finalizes auto-dismiss on the next animation frame.
+      jest.advanceTimersToNextFrame();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(SUCCESS_MESSAGE)).not.toBeInTheDocument();
+    });
+
+    expect(onAutoClose).toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
   it('should dismiss toast after auto-close duration', async () => {
     jest.useFakeTimers();
 
@@ -215,14 +301,19 @@ describe('toast utility - dismissal and interaction', () => {
     expect(await screen.findByText(WARNING_DESCRIPTION)).toBeInTheDocument();
 
     act(() => {
-      jest.advanceTimersByTime(4000);
+      jest.advanceTimersByTime(500);
     });
     expect(await screen.findByText(WARNING_DESCRIPTION)).toBeInTheDocument();
 
-    // It should auto-close after 8 seconds, we are at 6 seconds now
+    // It should auto-close after 3 seconds, we are at 2.5 seconds now.
     act(() => {
-      jest.advanceTimersByTime(4000);
+      jest.advanceTimersByTime(500);
       jest.runOnlyPendingTimers();
+    });
+
+    act(() => {
+      // Sonner finalizes auto-dismiss on the next animation frame.
+      jest.advanceTimersToNextFrame();
     });
 
     await waitFor(() => {
@@ -262,7 +353,7 @@ describe('toast utility - stable id updates', () => {
     expect(screen.queryByText('Synchronizing repository settings...')).not.toBeInTheDocument();
   });
 
-  it('should stop automatic aggregation immediately when a returned aggregated id is later reused explicitly', async () => {
+  it('should stop automatic aggregation after explicit reuse of an aggregated id', async () => {
     render(<div />);
 
     const repeatedToastId = trackToastId(
@@ -308,7 +399,7 @@ describe('toast utility - stable id updates', () => {
     expect(screen.queryByText(/^Shown \d+ times$/)).not.toBeInTheDocument();
   });
 
-  it('should not reuse an auto-generated repeated-toast id after the previous toast is dismissed', async () => {
+  it('should create a new generated id after the repeated toast is dismissed', async () => {
     render(<div />);
 
     const firstToastId = trackToastId(
@@ -409,7 +500,7 @@ describe('toast utility - automatic aggregation opt-outs', () => {
     });
 
     act(() => {
-      jest.advanceTimersByTime(8000);
+      jest.advanceTimersByTime(3000);
       jest.runOnlyPendingTimers();
     });
 

--- a/src/utils/toasts.tsx
+++ b/src/utils/toasts.tsx
@@ -35,20 +35,22 @@ export { ToastVariety } from '~common/components/Toast';
  */
 export enum ToastDuration {
   /**
-   * Short duration for toasts with only 1 line of text (8 seconds).
+   * Short duration (3 seconds) for brief transient toasts when a shorter-than-default lifetime is
+   * intentional.
    */
   Short = 'short',
   /**
-   * Medium duration for toasts with 2 lines of text (16 seconds) - default duration.
+   * Medium duration (5 seconds). This is the default for regular toasts.
    */
   Medium = 'medium',
   /**
-   * Long duration for toasts with 3 lines of text (24 seconds).
+   * Long duration (8 seconds). This is the default for toasts with actions, or for regular toasts
+   * that intentionally need a bit more time.
    */
   Long = 'long',
   /**
-   * Infinite duration toast that remains visible until manually dismissed.
-   * Mandatory when the toast has actions.
+   * Infinite duration for toasts that must remain visible until the user dismisses them, such as
+   * critical or complex errors.
    */
   Infinite = 'infinite',
 }
@@ -63,8 +65,12 @@ export interface ToastParams extends Omit<ToastProps, 'id' | 'repetitionCount'> 
    */
   id?: ToastId;
   /**
-   * How long the toast should remain visible (optional). The default is `medium`.
-   * Note: Toasts with actions must use infinite duration.
+   * How long the toast should remain visible (optional). The default is `medium` for regular
+   * toasts and `long` for toasts with actions.
+   * Set `short` or `long` explicitly only when the toast should be shorter- or longer-lived than
+   * those defaults.
+   * Use `infinite` explicitly for critical or complex errors that should stay visible until
+   * dismissal.
    */
   duration?: `${ToastDuration}`;
   /**
@@ -84,15 +90,7 @@ export interface ToastParams extends Omit<ToastProps, 'id' | 'repetitionCount'> 
 type ToastShortcutParams = Omit<ToastParams, 'variety'>;
 
 function toastFn(params: ToastParams, ref?: Ref<HTMLDivElement>): ToastId {
-  const {
-    duration = ToastDuration.Medium,
-    className,
-    id,
-    isDismissable,
-    onAutoClose,
-    onDismiss,
-    ...toastProps
-  } = params;
+  const { duration, className, id, isDismissable, onAutoClose, onDismiss, ...toastProps } = params;
 
   if (isDefined(id) && isRepeatedToastId(id)) {
     clearRepeatedToastTracking(id);
@@ -103,12 +101,12 @@ function toastFn(params: ToastParams, ref?: Ref<HTMLDivElement>): ToastId {
   const repeatedToastState = trackRepeatedToast(params);
   const repeatedToastId = repeatedToastState?.id;
   const repeatedToastCount = repeatedToastState?.count;
+  const hasActions = isDefined(toastProps.actions);
 
-  const durationValue = isDefined(toastProps.actions)
-    ? TOAST_DURATION_MAP[ToastDuration.Infinite]
-    : TOAST_DURATION_MAP[duration];
+  const resolvedDuration = duration ?? (hasActions ? ToastDuration.Long : ToastDuration.Medium);
 
-  const isDismissableValue = durationValue === Infinity || isDismissable;
+  const durationValue = TOAST_DURATION_MAP[resolvedDuration];
+  const isDismissableValue = durationValue === Infinity || hasActions || isDismissable;
   const visibleToastId = repeatedToastId ?? id;
   const trackedRepeatedToastId = isRepeatedToastId(visibleToastId) ? visibleToastId : undefined;
 
@@ -237,8 +235,10 @@ type ToastFn = {
  *
  * **Important Rules**
  *
- * - Toasts with actions must be dismissible and have infinite duration
+ * - Toasts with actions must be dismissible
  * - Infinite duration toasts must be dismissible
+ * - Use `ToastDuration.Infinite` explicitly for critical or complex errors that should stay
+ *   visible until dismissal
  *
  * **Basic Usage**
  *
@@ -273,12 +273,19 @@ type ToastFn = {
  *   title: "File uploaded",
  *   description: "Your file has been uploaded successfully.",
  *   isDismissable: true,
- *   duration: ToastDuration.Infinite,
  *   actions: ({ dismiss }) => (
  *     <Button onClick={dismiss}>
  *       View File
  *     </Button>
  *   )
+ * });
+ *
+ * // Critical or complex errors that must stay visible
+ * toast.error({
+ *   title: "Repository synchronization failed",
+ *   description: "Resolve the underlying issue before retrying.",
+ *   duration: ToastDuration.Infinite,
+ *   isDismissable: true
  * });
  *
  * // Manual dismiss of a toast using its ID
@@ -305,20 +312,15 @@ export const toast: ToastFn = Object.assign(toastFn, {
 });
 
 const TOAST_DURATION_MAP = {
-  [ToastDuration.Short]: 8000,
-  [ToastDuration.Medium]: 16000,
-  [ToastDuration.Long]: 24000,
+  [ToastDuration.Short]: 3000,
+  [ToastDuration.Medium]: 5000,
+  [ToastDuration.Long]: 8000,
   [ToastDuration.Infinite]: Infinity,
 } as const;
 
 type InvalidToastActionNoDismissable = {
   actions: Required<ToastParams['actions']>;
   isDismissable?: false;
-};
-
-type InvalidToastActionNoInfinite = {
-  actions: Required<ToastParams['actions']>;
-  duration?: `${Exclude<ToastDuration, ToastDuration.Infinite>}`;
 };
 
 type InvalidToastInfiniteNoDismissable = {
@@ -332,9 +334,7 @@ type InvalidToastInfiniteNoDismissable = {
  */
 type TypeGuardValidToastParams<T extends ToastShortcutParams> =
   T extends InvalidToastActionNoDismissable
-    ? '🚨 A toast with the `actions` param must also have the `isDismissable` param set to `true`'
-    : T extends InvalidToastActionNoInfinite
-      ? '🚨 A toast with the `actions` param must also have the `duration` param set to `infinite`'
-      : T extends InvalidToastInfiniteNoDismissable
-        ? '🚨 A toast with the `duration` param set to `infinite` must also have the `isDismissable` param set to `true`'
-        : T;
+    ? '🚨 A toast with `actions` must also set `isDismissable: true`'
+    : T extends InvalidToastInfiniteNoDismissable
+      ? '🚨 A toast with `duration: infinite` must also set `isDismissable: true`'
+      : T;

--- a/stories/Toast-stories.tsx
+++ b/stories/Toast-stories.tsx
@@ -43,8 +43,11 @@ const meta: Meta<ToastParams> = {
     },
     duration: {
       control: { type: 'select' },
+      description:
+        'Regular toasts default to medium (5 seconds). Toasts with actions default to long ' +
+        '(8 seconds).',
       table: {
-        defaultValue: { summary: 'medium' },
+        defaultValue: { summary: 'medium (regular) / long (with actions)' },
       },
 
       options: ['short', 'medium', 'long', 'infinite'],
@@ -138,8 +141,18 @@ export const WithActions: Story = {
   args: {
     className: 'custom-toast',
     description: 'This is a toast message',
+    isDismissable: true,
     title: 'Default Toast',
     variety: 'info',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Toasts with actions stay dismissable, and when no duration is provided they use the ' +
+          'long duration by default (8 seconds).',
+      },
+    },
   },
   render: (args) => {
     return (
@@ -153,8 +166,6 @@ export const WithActions: Story = {
             onDismiss: () => {
               console.log('Toast dismissed');
             },
-            isDismissable: true,
-            duration: 'infinite',
             actions: ({ id, dismiss }) => (
               <Button
                 onClick={() => {
@@ -166,7 +177,7 @@ export const WithActions: Story = {
             ),
           });
         }}>
-        Show dismissable toast
+        Show action toast
       </Button>
     );
   },


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored toast durations:**
  - Updated `Short`, `Medium`, and `Long` durations to 3s, 5s, and 8s respectively.
  - Set `Medium` as the default for regular toasts and `Long` as the default for toasts with actions.
- **Updated configuration:**
  - Reduced `EchoesProvider` default `toastsVisibleNb` from 5 to 3.
- **Improved type safety and documentation:**
  - Removed strict requirement for `infinite` duration on toasts with actions.
  - Clarified usage guidelines for `infinite` duration toasts in JSDoc and `Toast-stories`.
- **Updated testing:**
  - Adjusted existing tests to reflect new duration timings.
  - Added new test coverage for default auto-dismiss behavior on regular and action-based toasts.

<sub>This will update automatically on new commits.</sub>