### PR TITLE
SC-51598 Set CheckboxGroup label spacing to 12px

### DIFF
--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -26,6 +26,7 @@ import { type CheckboxProps, Checkbox } from '../checkbox/Checkbox';
 import {
   type ValidationProps,
   FormField,
+  FormFieldLabelSpacing,
   FormFieldProps,
   FormFieldValidation,
 } from '../form/FormField';
@@ -123,6 +124,7 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
         isRequired={isRequired}
         label={label}
         labelId={labelId}
+        labelSpacing={FormFieldLabelSpacing.Large}
         messageInvalid={messageInvalid}
         messageValid={messageValid}
         validation={validation}
@@ -133,7 +135,6 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy ?? labelId}
           data-alignment={alignment}
-          data-has-label={Boolean(label) || undefined}
           data-invalid={validation === FormFieldValidation.Invalid}
           id={controlId}
           ref={ref}
@@ -270,10 +271,6 @@ const CheckboxGroupRoot = styled.div`
   display: flex;
   flex-direction: column;
   row-gap: ${cssVar('dimension-space-100')};
-
-  &[data-has-label] {
-    padding-top: ${cssVar('dimension-space-150')};
-  }
 
   &[data-alignment='horizontal'] {
     flex-direction: row;

--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -272,7 +272,7 @@ const CheckboxGroupRoot = styled.div`
   row-gap: ${cssVar('dimension-space-100')};
 
   &[data-has-label] {
-    padding-top: ${cssVar('dimension-space-75')};
+    padding-top: ${cssVar('dimension-space-150')};
   }
 
   &[data-alignment='horizontal'] {

--- a/src/components/checkbox-group/CheckboxGroup.tsx
+++ b/src/components/checkbox-group/CheckboxGroup.tsx
@@ -133,6 +133,7 @@ export const CheckboxGroup: CheckboxGroup = forwardRef<HTMLDivElement, CheckboxG
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy ?? labelId}
           data-alignment={alignment}
+          data-has-label={Boolean(label) || undefined}
           data-invalid={validation === FormFieldValidation.Invalid}
           id={controlId}
           ref={ref}
@@ -269,6 +270,10 @@ const CheckboxGroupRoot = styled.div`
   display: flex;
   flex-direction: column;
   row-gap: ${cssVar('dimension-space-100')};
+
+  &[data-has-label] {
+    padding-top: ${cssVar('dimension-space-75')};
+  }
 
   &[data-alignment='horizontal'] {
     flex-direction: row;

--- a/src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
+++ b/src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
@@ -21,6 +21,7 @@ import { screen } from '@testing-library/react';
 import { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { useState } from 'react';
 import { render } from '~common/helpers/test-utils';
+import { cssVar } from '~utils/design-tokens';
 import { CheckboxGroup } from '../CheckboxGroup';
 
 it('displays a label and description', () => {
@@ -36,6 +37,15 @@ it('displays a label and description', () => {
 
   const group = screen.getByRole('group', { description: 'Help text', name: 'Label' });
   expect(group).toBeVisible();
+});
+
+it('adds 12px spacing between the group label and the checkboxes', () => {
+  render(
+    <CheckboxGroup label="Label" onChange={() => {}} options={[{ label: 'Option' }]} value={[]} />,
+  );
+
+  const group = screen.getByRole('group', { name: 'Label' });
+  expect(group).toHaveStyle({ paddingTop: cssVar('dimension-space-75') });
 });
 
 it('calls onChange when the value changes', async () => {

--- a/src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
+++ b/src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
@@ -45,7 +45,7 @@ it('adds 12px spacing between the group label and the checkboxes', () => {
   );
 
   const group = screen.getByRole('group', { name: 'Label' });
-  expect(group).toHaveStyle({ paddingTop: cssVar('dimension-space-75') });
+  expect(group).toHaveStyle({ paddingTop: cssVar('dimension-space-150') });
 });
 
 it('calls onChange when the value changes', async () => {

--- a/src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
+++ b/src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
@@ -44,8 +44,9 @@ it('adds 12px spacing between the group label and the checkboxes', () => {
     <CheckboxGroup label="Label" onChange={() => {}} options={[{ label: 'Option' }]} value={[]} />,
   );
 
-  const group = screen.getByRole('group', { name: 'Label' });
-  expect(group).toHaveStyle({ paddingTop: cssVar('dimension-space-150') });
+  const label = screen.getByText('Label');
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(label.parentElement).toHaveStyle({ marginBottom: cssVar('dimension-space-150') });
 });
 
 it('calls onChange when the value changes', async () => {

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -22,9 +22,11 @@ import { type ComponentProps, type JSX, forwardRef } from 'react';
 import { TextNodeOptional } from '~types/utils';
 import { MessageInline, MessageInlineSize, MessageVariety } from '../messages';
 import { HelperText } from '../typography';
-import { FormFieldLabel, FormFieldLabelProps } from './FormFieldLabel';
+import { FormFieldLabel, FormFieldLabelProps, FormFieldLabelSpacing } from './FormFieldLabel';
 
 import { cssVar } from '~utils/design-tokens';
+
+export { FormFieldLabelSpacing };
 
 /**
  * Form fields wrap form controls and help create standardization between them.
@@ -136,11 +138,6 @@ export enum FormFieldWidth {
   Medium = 'medium',
   Large = 'large',
   Full = 'full',
-}
-
-export enum FormFieldLabelSpacing {
-  Default = 'default',
-  Large = 'large',
 }
 
 type WhiteListedProps = Pick<ComponentProps<'div'>, 'className'>;

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -62,6 +62,7 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
     isRequired = false,
     label,
     labelId,
+    labelSpacing = FormFieldLabelSpacing.Default,
     messageInvalid,
     messageValid,
     validation,
@@ -89,7 +90,8 @@ export const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref)
         htmlFor={controlId}
         id={labelId}
         isDisabled={isDisabled}
-        isRequired={isRequired}>
+        isRequired={isRequired}
+        spacing={labelSpacing}>
         {label}
       </FormFieldLabel>
       {children}
@@ -134,6 +136,11 @@ export enum FormFieldWidth {
   Medium = 'medium',
   Large = 'large',
   Full = 'full',
+}
+
+export enum FormFieldLabelSpacing {
+  Default = 'default',
+  Large = 'large',
 }
 
 type WhiteListedProps = Pick<ComponentProps<'div'>, 'className'>;
@@ -192,6 +199,12 @@ export interface FormFieldProps extends ValidationProps, WhiteListedProps {
    * The ID of the label for the form field (optional).
    */
   labelId?: FormFieldLabelProps['id'];
+  /**
+   * Controls the spacing between the label and the form control.
+   *
+   * @internal
+   */
+  labelSpacing?: `${FormFieldLabelSpacing}`;
   /**
    * The props for a help toggletip showing next to the form field label to provide additional information about the field (optional).
    */

--- a/src/components/form/FormFieldLabel.tsx
+++ b/src/components/form/FormFieldLabel.tsx
@@ -26,6 +26,11 @@ import { Label } from '../typography';
 
 import { cssVar } from '~utils/design-tokens';
 
+export enum FormFieldLabelSpacing {
+  Default = 'default',
+  Large = 'large',
+}
+
 export interface FormFieldLabelProps {
   children?: TextNodeOptional;
   /**
@@ -47,7 +52,7 @@ export interface FormFieldLabelProps {
   /**
    * Controls the spacing below the label.
    */
-  spacing?: 'default' | 'large';
+  spacing?: `${FormFieldLabelSpacing}`;
   /**
    * The props for a help toggletip showing next to the form field label to provide additional information about the field (optional).
    */
@@ -73,7 +78,7 @@ export const FormFieldLabel = forwardRef<HTMLLabelElement, FormFieldLabelProps>(
     isDisabled = false,
     isRequired = false,
     helpToggletipProps,
-    spacing = 'default',
+    spacing = FormFieldLabelSpacing.Default,
     ...rest
   } = props;
 

--- a/src/components/form/FormFieldLabel.tsx
+++ b/src/components/form/FormFieldLabel.tsx
@@ -45,6 +45,10 @@ export interface FormFieldLabelProps {
    */
   isRequired?: boolean;
   /**
+   * Controls the spacing below the label.
+   */
+  spacing?: 'default' | 'large';
+  /**
    * The props for a help toggletip showing next to the form field label to provide additional information about the field (optional).
    */
   helpToggletipProps?: ToggleTipProps;
@@ -64,14 +68,21 @@ export interface FormFieldLabelProps {
  * @internal
  */
 export const FormFieldLabel = forwardRef<HTMLLabelElement, FormFieldLabelProps>((props, ref) => {
-  const { children, isDisabled = false, isRequired = false, helpToggletipProps, ...rest } = props;
+  const {
+    children,
+    isDisabled = false,
+    isRequired = false,
+    helpToggletipProps,
+    spacing = 'default',
+    ...rest
+  } = props;
 
   if (!children) {
     return null;
   }
 
   return (
-    <LabelWrapper>
+    <LabelWrapper data-spacing={spacing}>
       <LabelStyled data-disabled={isDisabled || undefined} ref={ref} {...rest}>
         {children}
         {isRequired && <RequiredIndicator aria-hidden="true">*</RequiredIndicator>}
@@ -89,6 +100,10 @@ const LabelWrapper = styled.div`
   gap: ${cssVar('dimension-space-75')};
 
   margin-bottom: ${cssVar('dimension-space-75')};
+
+  &[data-spacing='large'] {
+    margin-bottom: ${cssVar('dimension-space-150')};
+  }
 `;
 LabelWrapper.displayName = 'LabelWrapper';
 

--- a/src/components/form/__tests__/FormField-test.tsx
+++ b/src/components/form/__tests__/FormField-test.tsx
@@ -19,7 +19,13 @@
  */
 import { screen } from '@testing-library/react';
 import { render } from '~common/helpers/test-utils';
-import { FormField, FormFieldValidation, FormFieldWidth } from '../FormField';
+import { cssVar } from '~utils/design-tokens';
+import {
+  FormField,
+  FormFieldLabelSpacing,
+  FormFieldValidation,
+  FormFieldWidth,
+} from '../FormField';
 
 it('displays a label', () => {
   render(
@@ -30,6 +36,30 @@ it('displays a label', () => {
   const label = screen.getByText('Label 1');
   expect(label).toBeVisible();
   expect(label.tagName).toBe('LABEL');
+});
+
+it('uses default spacing between the label and control', () => {
+  render(
+    <FormField label="Label 1">
+      <input />
+    </FormField>,
+  );
+
+  const label = screen.getByText('Label 1');
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(label.parentElement).toHaveStyle({ marginBottom: cssVar('dimension-space-75') });
+});
+
+it('supports large spacing between the label and control', () => {
+  render(
+    <FormField label="Label 1" labelSpacing={FormFieldLabelSpacing.Large}>
+      <input />
+    </FormField>,
+  );
+
+  const label = screen.getByText('Label 1');
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(label.parentElement).toHaveStyle({ marginBottom: cssVar('dimension-space-150') });
 });
 
 it('displays an asterisk next to the label if the form field is required', () => {

--- a/src/components/radio-button-group/RadioButtonGroup.tsx
+++ b/src/components/radio-button-group/RadioButtonGroup.tsx
@@ -23,7 +23,7 @@ import * as RadioGroup from '@radix-ui/react-radio-group';
 import { forwardRef, useId } from 'react';
 import { GroupAlignment } from '~types/GroupAlignment';
 import { PropsWithLabels } from '~types/utils';
-import { FormField, FormFieldValidation } from '../form/FormField';
+import { FormField, FormFieldLabelSpacing, FormFieldValidation } from '../form/FormField';
 import { useFormFieldA11y } from '../form/useFormFieldA11y';
 import { RadioButton } from './RadioButton';
 import { RadioButtonGroupProps } from './RadioButtonTypes';
@@ -70,6 +70,7 @@ export const RadioButtonGroup = forwardRef<HTMLDivElement, PropsWithLabels<Radio
         isRequired={required}
         label={label}
         labelId={labelId}
+        labelSpacing={FormFieldLabelSpacing.Large}
         messageInvalid={messageInvalid}
         messageValid={messageValid}
         validation={validation}

--- a/src/components/radio-button-group/__tests__/RadioButtonGroup-test.tsx
+++ b/src/components/radio-button-group/__tests__/RadioButtonGroup-test.tsx
@@ -21,6 +21,7 @@
 import { screen } from '@testing-library/react';
 import { OmitPropsWithLabels, render } from '~common/helpers/test-utils';
 import { GroupAlignment } from '~types/GroupAlignment';
+import { cssVar } from '~utils/design-tokens';
 import { RadioButtonGroup } from '../RadioButtonGroup';
 
 const DEFAULT_OPTIONS = [
@@ -98,6 +99,14 @@ describe('RadioButtonGroup', () => {
     renderRadioButtonGroup({ isRequired: true, label: <span>Group label</span> });
 
     expect(screen.getByText('Group label')).toBeVisible();
+  });
+
+  it('adds 12px spacing between the group label and the radio buttons', () => {
+    renderRadioButtonGroup({ label: 'Radio group label' });
+
+    const label = screen.getByText('Radio group label');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(label.parentElement).toHaveStyle({ marginBottom: cssVar('dimension-space-150') });
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

- Set CheckboxGroup label-to-options spacing to 12px when a group label is present.
- Add test coverage for the CheckboxGroup label spacing token.

Jira: https://sonarsource.atlassian.net/browse/SC-51598

## How to test?

1. Open the CheckboxGroup Valid story in Storybook.
2. Verify the visual gap between the group label and first checkbox is 12px.

## Validation

- yarn jest src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
- yarn prettier --check src/components/checkbox-group/CheckboxGroup.tsx src/components/checkbox-group/__tests__/CheckboxGroup-test.tsx
- yarn validate

----
## Summary by Gitar

- **Form component updates:**
  - Added `labelSpacing` prop to `FormField` to control the bottom margin of the label.
  - Introduced `FormFieldLabelSpacing` enum to support `default` and `large` spacing tokens.
- **Component styling:**
  - Updated `CheckboxGroup` and `RadioButtonGroup` to use `FormFieldLabelSpacing.Large` for better alignment.
- **Testing improvements:**
  - Added tests for `FormField` spacing variants and verified spacing in `CheckboxGroup` and `RadioButtonGroup`.

<sub>This will update automatically on new commits.</sub>