### PR TITLE
SC-51613 Remove card body min-height

### DIFF
--- a/src/components/card/CardBody.tsx
+++ b/src/components/card/CardBody.tsx
@@ -38,12 +38,7 @@ export const CardBody = React.forwardRef<HTMLDivElement, Readonly<CardBodyProps>
     }
 
     return (
-      <CardBodyStyled
-        className={className}
-        css={sizeStyles}
-        insetContent={insetContent}
-        ref={ref}
-        size={size}>
+      <CardBodyStyled className={className} css={sizeStyles} insetContent={insetContent} ref={ref}>
         {children}
       </CardBodyStyled>
     );

--- a/src/components/card/CardHeader.tsx
+++ b/src/components/card/CardHeader.tsx
@@ -120,7 +120,7 @@ export const CardHeader = React.forwardRef<HTMLDivElement, Readonly<CardHeaderPr
             }),
             [sizeConfig.styles],
           )}
-          noPadding={isFullyCollapsible}
+          disablePadding={isFullyCollapsible}
           ref={ref}>
           {isFullyCollapsible ? (
             <CardHeaderTitleButtonStyled

--- a/src/components/card/CardStyles.tsx
+++ b/src/components/card/CardStyles.tsx
@@ -84,6 +84,7 @@ export const CardHeaderTitleButtonStyled = styled(ButtonStyled)`
   display: flex;
   flex-direction: row;
   flex: 1;
+  /* ButtonStyled sets fixed dimensions; this header button sizes from padding instead. */
   height: auto;
   min-height: auto;
   padding: var(--card-header-padding);

--- a/src/components/card/CardStyles.tsx
+++ b/src/components/card/CardStyles.tsx
@@ -96,7 +96,6 @@ CardHeaderTitleButtonStyled.displayName = 'CardHeaderTitleButtonStyled';
 
 export const CardBodyStyled = styled.div<{ size: `${CardSize}`; insetContent: boolean }>`
   box-sizing: border-box;
-  min-height: var(--card-body-min-height);
   padding: ${(props) => (props.insetContent ? '0' : 'var(--card-padding)')};
   width: 100%;
 
@@ -126,15 +125,12 @@ export const CARD_HEADER_SIZE_STYLES = {
 
 export const CARD_SIZE_STYLES = {
   [CardSize.Large]: {
-    '--card-body-min-height': '108px',
     '--card-padding': cssVar('dimension-space-300'),
   },
   [CardSize.Medium]: {
-    '--card-body-min-height': '92px',
     '--card-padding': cssVar('dimension-space-200'),
   },
   [CardSize.Small]: {
-    '--card-body-min-height': '84px',
     '--card-padding': cssVar('dimension-space-150'),
   },
 };

--- a/src/components/card/CardStyles.tsx
+++ b/src/components/card/CardStyles.tsx
@@ -65,7 +65,6 @@ export const RightContentStyled = styled.div`
   align-items: center;
   display: flex;
   gap: ${cssVar('dimension-space-100')};
-  max-height: var(--card-header-heading-height);
 `;
 RightContentStyled.displayName = 'RightContentStyled';
 
@@ -107,15 +106,12 @@ CardBodyStyled.displayName = 'CardBodyStyled';
 
 export const CARD_HEADER_SIZE_STYLES = {
   [CardSize.Large]: {
-    '--card-header-heading-height': '1.875rem',
-    '--card-header-padding': `${cssVar('dimension-space-200')} ${cssVar('dimension-space-300')}`,
+    '--card-header-padding': `${cssVar('dimension-space-250')} ${cssVar('dimension-space-300')}`,
   },
   [CardSize.Medium]: {
-    '--card-header-heading-height': '1.5rem',
     '--card-header-padding': `${cssVar('dimension-space-150')} ${cssVar('dimension-space-200')}`,
   },
   [CardSize.Small]: {
-    '--card-header-heading-height': '1.25rem',
     '--card-header-padding': `${cssVar('dimension-space-100')} ${cssVar('dimension-space-150')}`,
   },
 };

--- a/src/components/card/CardStyles.tsx
+++ b/src/components/card/CardStyles.tsx
@@ -41,7 +41,6 @@ CardStyled.displayName = 'CardStyled';
 export const CardHeaderStyled = styled.header<{ noPadding: boolean }>`
   align-items: center;
   display: flex;
-  min-height: var(--card-header-min-height);
   ${({ noPadding }) => (noPadding ? '' : 'padding: var(--card-header-padding);')}
 `;
 CardHeaderStyled.displayName = 'CardHeaderStyled';
@@ -86,7 +85,8 @@ export const CardHeaderTitleButtonStyled = styled(ButtonStyled)`
   display: flex;
   flex-direction: row;
   flex: 1;
-  min-height: var(--card-header-min-height);
+  height: auto;
+  min-height: auto;
   padding: var(--card-header-padding);
 
   border-bottom-right-radius: 0;
@@ -108,17 +108,14 @@ CardBodyStyled.displayName = 'CardBodyStyled';
 export const CARD_HEADER_SIZE_STYLES = {
   [CardSize.Large]: {
     '--card-header-heading-height': '1.875rem',
-    '--card-header-min-height': '58px',
     '--card-header-padding': `${cssVar('dimension-space-200')} ${cssVar('dimension-space-300')}`,
   },
   [CardSize.Medium]: {
     '--card-header-heading-height': '1.5rem',
-    '--card-header-min-height': '45px',
     '--card-header-padding': `${cssVar('dimension-space-150')} ${cssVar('dimension-space-200')}`,
   },
   [CardSize.Small]: {
     '--card-header-heading-height': '1.25rem',
-    '--card-header-min-height': '36px',
     '--card-header-padding': `${cssVar('dimension-space-100')} ${cssVar('dimension-space-150')}`,
   },
 };

--- a/src/components/card/CardStyles.tsx
+++ b/src/components/card/CardStyles.tsx
@@ -48,7 +48,6 @@ CardHeaderStyled.displayName = 'CardHeaderStyled';
 
 export const CardBodyStyled = styled.div<{ size: `${CardSize}`; insetContent: boolean }>`
   box-sizing: border-box;
-  min-height: var(--card-body-min-height);
   padding: ${(props) => (props.insetContent ? '0' : 'var(--card-padding)')};
   width: 100%;
 
@@ -76,14 +75,11 @@ export const CARD_HEADER_SIZE_STYLES = {
 export const CARD_SIZE_STYLES = {
   [CardSize.Small]: {
     '--card-padding': cssVar('dimension-space-150'),
-    '--card-body-min-height': '84px',
   },
   [CardSize.Medium]: {
     '--card-padding': cssVar('dimension-space-200'),
-    '--card-body-min-height': '92px',
   },
   [CardSize.Large]: {
     '--card-padding': cssVar('dimension-space-300'),
-    '--card-body-min-height': '108px',
   },
 };

--- a/src/components/card/CardStyles.tsx
+++ b/src/components/card/CardStyles.tsx
@@ -38,10 +38,10 @@ export const CardStyled = styled.div`
 `;
 CardStyled.displayName = 'CardStyled';
 
-export const CardHeaderStyled = styled.header<{ noPadding: boolean }>`
+export const CardHeaderStyled = styled.header<{ disablePadding: boolean }>`
   align-items: center;
   display: flex;
-  ${({ noPadding }) => (noPadding ? '' : 'padding: var(--card-header-padding);')}
+  ${({ disablePadding }) => (disablePadding ? '' : 'padding: var(--card-header-padding);')}
 `;
 CardHeaderStyled.displayName = 'CardHeaderStyled';
 
@@ -94,7 +94,7 @@ export const CardHeaderTitleButtonStyled = styled(ButtonStyled)`
 `;
 CardHeaderTitleButtonStyled.displayName = 'CardHeaderTitleButtonStyled';
 
-export const CardBodyStyled = styled.div<{ size: `${CardSize}`; insetContent: boolean }>`
+export const CardBodyStyled = styled.div<{ insetContent: boolean }>`
   box-sizing: border-box;
   padding: ${(props) => (props.insetContent ? '0' : 'var(--card-padding)')};
   width: 100%;

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -91,19 +91,6 @@ describe('Card components', () => {
       expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
     });
 
-    it('does not apply a minimum height', () => {
-      const ref = React.createRef<HTMLDivElement>();
-
-      render(
-        <CardRoot>
-          <CardHeader ref={ref} title="Card Title" />
-        </CardRoot>,
-      );
-
-      expect(ref.current).not.toBeNull();
-      expect(window.getComputedStyle(ref.current as HTMLElement).minHeight).toBe('');
-    });
-
     it('defines header size through padding only', () => {
       expect(CARD_HEADER_SIZE_STYLES).toEqual({
         [CardSize.Large]: {
@@ -182,16 +169,6 @@ describe('Card components', () => {
       expect(ref.current).not.toBeNull();
     });
 
-    it('does not apply a minimum height', () => {
-      render(
-        <CardRoot>
-          <CardBody>Content</CardBody>
-        </CardRoot>,
-      );
-
-      expect(window.getComputedStyle(screen.getByText('Content')).minHeight).toBe('');
-    });
-
     it('applies insetContent prop correctly', () => {
       const { rerender } = render(
         <CardRoot>
@@ -249,6 +226,23 @@ describe('Card components', () => {
       expect(screen.getByText('Card Title')).toBeInTheDocument();
       expect(screen.getByText('Card Description')).toBeInTheDocument();
       expect(screen.getByText('Actions')).toBeInTheDocument();
+    });
+
+    it('does not apply a minimum height to the header or body', () => {
+      const headerRef = React.createRef<HTMLDivElement>();
+      const bodyRef = React.createRef<HTMLDivElement>();
+
+      render(
+        <CardRoot>
+          <CardHeader ref={headerRef} title="Card Title" />
+          <CardBody ref={bodyRef}>Content</CardBody>
+        </CardRoot>,
+      );
+
+      expect(headerRef.current).not.toBeNull();
+      expect(window.getComputedStyle(headerRef.current as HTMLElement).minHeight).toBe('');
+      expect(bodyRef.current).not.toBeNull();
+      expect(window.getComputedStyle(bodyRef.current as HTMLElement).minHeight).toBe('');
     });
   });
 

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -27,6 +27,7 @@ import { CardBody } from '../CardBody';
 import { CardHeader } from '../CardHeader';
 import { CardRoot } from '../CardRoot';
 import { CardSize } from '../CardSize';
+import { CARD_HEADER_SIZE_STYLES } from '../CardStyles';
 
 describe('Card components', () => {
   describe('CardRoot', () => {
@@ -101,6 +102,23 @@ describe('Card components', () => {
 
       expect(header).not.toBeNull();
       expect(window.getComputedStyle(header as HTMLElement).minHeight).toBe('');
+    });
+
+    it('defines header size through padding only', () => {
+      expect(CARD_HEADER_SIZE_STYLES).toEqual({
+        [CardSize.Large]: {
+          '--card-header-padding':
+            'var(--echoes-dimension-space-250) var(--echoes-dimension-space-300)',
+        },
+        [CardSize.Medium]: {
+          '--card-header-padding':
+            'var(--echoes-dimension-space-150) var(--echoes-dimension-space-200)',
+        },
+        [CardSize.Small]: {
+          '--card-header-padding':
+            'var(--echoes-dimension-space-100) var(--echoes-dimension-space-150)',
+        },
+      });
     });
 
     it('uses correct heading level based on card size', () => {

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -139,6 +139,16 @@ describe('Card components', () => {
       expect(ref.current).not.toBeNull();
     });
 
+    it('does not apply a minimum height', () => {
+      render(
+        <CardRoot>
+          <CardBody>Content</CardBody>
+        </CardRoot>,
+      );
+
+      expect(window.getComputedStyle(screen.getByText('Content')).minHeight).toBe('');
+    });
+
     it('applies insetContent prop correctly', () => {
       const { rerender } = render(
         <CardRoot>

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -27,7 +27,7 @@ import { CardBody } from '../CardBody';
 import { CardHeader } from '../CardHeader';
 import { CardRoot } from '../CardRoot';
 import { CardSize } from '../CardSize';
-import { CARD_HEADER_SIZE_STYLES } from '../CardStyles';
+import { CARD_HEADER_SIZE_STYLES, CARD_SIZE_STYLES } from '../CardStyles';
 
 describe('Card components', () => {
   describe('CardRoot', () => {
@@ -91,7 +91,7 @@ describe('Card components', () => {
       expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
     });
 
-    it('defines header size through padding only', () => {
+    it('defines header and body size through padding only', () => {
       expect(CARD_HEADER_SIZE_STYLES).toEqual({
         [CardSize.Large]: {
           '--card-header-padding':
@@ -104,6 +104,18 @@ describe('Card components', () => {
         [CardSize.Small]: {
           '--card-header-padding':
             'var(--echoes-dimension-space-100) var(--echoes-dimension-space-150)',
+        },
+      });
+
+      expect(CARD_SIZE_STYLES).toEqual({
+        [CardSize.Large]: {
+          '--card-padding': 'var(--echoes-dimension-space-300)',
+        },
+        [CardSize.Medium]: {
+          '--card-padding': 'var(--echoes-dimension-space-200)',
+        },
+        [CardSize.Small]: {
+          '--card-padding': 'var(--echoes-dimension-space-150)',
         },
       });
     });
@@ -226,23 +238,6 @@ describe('Card components', () => {
       expect(screen.getByText('Card Title')).toBeInTheDocument();
       expect(screen.getByText('Card Description')).toBeInTheDocument();
       expect(screen.getByText('Actions')).toBeInTheDocument();
-    });
-
-    it('does not apply a minimum height to the header or body', () => {
-      const headerRef = React.createRef<HTMLDivElement>();
-      const bodyRef = React.createRef<HTMLDivElement>();
-
-      render(
-        <CardRoot>
-          <CardHeader ref={headerRef} title="Card Title" />
-          <CardBody ref={bodyRef}>Content</CardBody>
-        </CardRoot>,
-      );
-
-      expect(headerRef.current).not.toBeNull();
-      expect(window.getComputedStyle(headerRef.current as HTMLElement).minHeight).toBe('');
-      expect(bodyRef.current).not.toBeNull();
-      expect(window.getComputedStyle(bodyRef.current as HTMLElement).minHeight).toBe('');
     });
   });
 

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -179,6 +179,7 @@ describe('Card components', () => {
       );
 
       expect(ref.current).not.toBeNull();
+      expect(ref.current).not.toHaveAttribute('size');
     });
 
     it('applies insetContent prop correctly', () => {

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -298,9 +298,9 @@ describe('Card components', () => {
         </CardRoot>,
       );
 
-      expect(window.getComputedStyle(screen.getByRole('button', { name: 'Collapse' })).minHeight).toBe(
-        'auto',
-      );
+      expect(
+        window.getComputedStyle(screen.getByRole('button', { name: 'Collapse' })).minHeight,
+      ).toBe('auto');
     });
 
     it('does not render a toggle button when isCollapsible is false', () => {

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -92,16 +92,16 @@ describe('Card components', () => {
     });
 
     it('does not apply a minimum height', () => {
+      const ref = React.createRef<HTMLDivElement>();
+
       render(
         <CardRoot>
-          <CardHeader title="Card Title" />
+          <CardHeader ref={ref} title="Card Title" />
         </CardRoot>,
       );
 
-      const header = screen.getByText('Card Title').closest('header');
-
-      expect(header).not.toBeNull();
-      expect(window.getComputedStyle(header as HTMLElement).minHeight).toBe('');
+      expect(ref.current).not.toBeNull();
+      expect(window.getComputedStyle(ref.current as HTMLElement).minHeight).toBe('');
     });
 
     it('defines header size through padding only', () => {

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -90,6 +90,19 @@ describe('Card components', () => {
       expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
     });
 
+    it('does not apply a minimum height', () => {
+      render(
+        <CardRoot>
+          <CardHeader title="Card Title" />
+        </CardRoot>,
+      );
+
+      const header = screen.getByText('Card Title').closest('header');
+
+      expect(header).not.toBeNull();
+      expect(window.getComputedStyle(header as HTMLElement).minHeight).toBe('');
+    });
+
     it('uses correct heading level based on card size', () => {
       const { rerender } = render(
         <CardRoot size={CardSize.Small}>
@@ -256,6 +269,20 @@ describe('Card components', () => {
       );
 
       expect(screen.getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
+    });
+
+    it('does not apply a minimum height to the collapsible header button', () => {
+      render(
+        <CardRoot isCollapsible>
+          <CardHeader title="Collapsible Card" />
+
+          <CardBody>Card Content</CardBody>
+        </CardRoot>,
+      );
+
+      expect(window.getComputedStyle(screen.getByRole('button', { name: 'Collapse' })).minHeight).toBe(
+        'auto',
+      );
     });
 
     it('does not render a toggle button when isCollapsible is false', () => {

--- a/src/components/card/__tests__/Card-test.tsx
+++ b/src/components/card/__tests__/Card-test.tsx
@@ -151,6 +151,16 @@ describe('Card components', () => {
       expect(ref.current).not.toBeNull();
     });
 
+    it('does not apply a minimum height', () => {
+      render(
+        <CardRoot>
+          <CardBody>Content</CardBody>
+        </CardRoot>,
+      );
+
+      expect(window.getComputedStyle(screen.getByText('Content')).minHeight).toBe('');
+    });
+
     it('applies insetContent prop correctly', () => {
       const { rerender } = render(
         <CardRoot>


### PR DESCRIPTION
## Summary
- Remove the size-driven min-height from Card.Body
- Keep Card.Body padding controlled by card size
- Add a regression test for Card.Body min-height

## Test
- yarn jest src/components/card/__tests__/Card-test.tsx

----
## Summary by Gitar

- **Refactored component styles:**
  - Removed `min-height` and `max-height` variables from `CardHeaderStyled`, `RightContentStyled`, and `CardHeaderTitleButtonStyled`
  - Updated `CARD_HEADER_SIZE_STYLES` to rely on padding-based sizing instead of explicit height variables
- **Regression testing:**
  - Added tests to verify `min-height` is unset for `CardHeader`, `CardBody`, and collapsible header buttons
  - Added unit tests to ensure `CARD_HEADER_SIZE_STYLES` and `CARD_SIZE_STYLES` only use padding configurations


<sub>This will update automatically on new commits.</sub>