### PR TITLE
ECHOES-1410 Add id props to main layout slots

### DIFF
--- a/src/components/layout/LayoutSlots.tsx
+++ b/src/components/layout/LayoutSlots.tsx
@@ -103,6 +103,7 @@ StyledAsideLeft.displayName = 'StyledAside';
 
 export interface PageGridProps {
   className?: string;
+  id?: string;
   /**
    * Setting this prop will make this component behave like a LoadingContainer.
    * It will provide a LoadingContext that LoadingSkeletons can consume (automatically),
@@ -202,6 +203,7 @@ const PAGE_WIDTH_STYLES: Record<PageWidth, CSSProperties> = {
 
 export interface PageContentProps {
   className?: string;
+  id?: string;
   /**
    * Setting this prop will make this component behave like a LoadingContainer.
    * It will provide a LoadingContext that LoadingSkeletons can consume (automatically),


### PR DESCRIPTION
----
## Summary by Gitar

- **Component Enhancements:**
  - Added optional `id` prop to `PageGridProps` interface in `LayoutSlots.tsx`.
  - Added optional `id` prop to `PageContentProps` interface in `LayoutSlots.tsx`.

<sub>This will update automatically on new commits.</sub>