### PR TITLE
ECHOES-1071 Add missing max-height on FilterDropdown

### DIFF
--- a/design-tokens/tokens/component/base.json
+++ b/design-tokens/tokens/component/base.json
@@ -36,6 +36,12 @@
               "$type": "sizing",
               "$value": "350px"
             }
+          },
+          "maxHeight": {
+            "default": {
+              "$type": "sizing",
+              "$value": "600px"
+            }
           }
         }
       },

--- a/src/components/badges/BadgeSeverity.tsx
+++ b/src/components/badges/BadgeSeverity.tsx
@@ -424,7 +424,7 @@ const BADGE_SEVERITY_INFO_STYLE = {
     'severity-badge-colors-background-severity-info-suffix-hover',
   ),
 };
-export const BADGE_SEVERITY_STYLES = {
+export const BADGE_SEVERITY_STYLES: Record<BadgeSeverityLevel, Record<string, string>> = {
   [BadgeSeverityLevel.Blocker]: BADGE_SEVERITY_BLOCKER_STYLE,
   [BadgeSeverityLevel.High]: BADGE_SEVERITY_HIGH_STYLE,
   [BadgeSeverityLevel.Info]: BADGE_SEVERITY_INFO_STYLE,

--- a/src/components/filters/FilterDropdownStyles.ts
+++ b/src/components/filters/FilterDropdownStyles.ts
@@ -35,6 +35,7 @@ export const filterDropdownRowStyles = css`
 export const StyledFilterContent = styled(stylePopoverContentBase(RadixPopover.Content))`
   display: flex;
   flex-direction: column;
+  max-height: ${cssVar('filter-dropdown-sizes-max-height-default')};
   min-height: ${cssVar('filter-dropdown-sizes-min-height-default')};
   overflow: visible;
   width: ${cssVar('sizes-overlays-width-default')};

--- a/src/components/filters/FilterDropdownTrigger.tsx
+++ b/src/components/filters/FilterDropdownTrigger.tsx
@@ -21,6 +21,7 @@
 import { BadgeCounter, BadgeCounterVariety } from '../badges/BadgeCounter';
 import { Button } from '../buttons';
 import { ButtonAsButtonProps } from '../buttons/Button';
+import { IconFilter } from '../icons';
 import { IconChevronDown } from '../icons/IconChevronDown';
 
 export interface FilterDropdownTriggerProps extends Omit<ButtonAsButtonProps, 'suffix'> {
@@ -32,6 +33,7 @@ export function FilterDropdownTrigger(props: Readonly<FilterDropdownTriggerProps
   const { children, selectedCount, ...restProps } = props;
   return (
     <Button
+      prefix={<IconFilter />}
       {...restProps}
       suffix={
         <>

--- a/src/generated/design-tokens-base.css
+++ b/src/generated/design-tokens-base.css
@@ -125,6 +125,7 @@
   --echoes-badge-sizes-height-medium: 1.75rem;
   --echoes-filter-dropdown-sizes-left-panel-width-default: 277px;
   --echoes-filter-dropdown-sizes-min-height-default: 350px;
+  --echoes-filter-dropdown-sizes-max-height-default: 600px;
   --echoes-filter-tag-sizes-max-width-default: 200px;
   --echoes-form-control-border-radius-default: 8px;
   --echoes-form-control-sizes-height-default: 2.25rem;

--- a/src/generated/design-tokens-base.json
+++ b/src/generated/design-tokens-base.json
@@ -103,6 +103,7 @@
   "echoes-badge-sizes-height-medium": "1.75rem",
   "echoes-filter-dropdown-sizes-left-panel-width-default": "277px",
   "echoes-filter-dropdown-sizes-min-height-default": "350px",
+  "echoes-filter-dropdown-sizes-max-height-default": "600px",
   "echoes-filter-tag-sizes-max-width-default": "200px",
   "echoes-form-control-border-radius-default": "8px",
   "echoes-form-control-sizes-height-default": "2.25rem",

--- a/stories/Breadcrumbs-stories.tsx
+++ b/stories/Breadcrumbs-stories.tsx
@@ -26,7 +26,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Breadcrumbs> = {
   component: Breadcrumbs,
-  title: 'Echoes/Breadcrumbs',
+  title: 'Echoes Components/Breadcrumbs',
   decorators: [basicWrapperDecorator],
 };
 

--- a/stories/Button-stories.tsx
+++ b/stories/Button-stories.tsx
@@ -36,7 +36,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  title: 'Echoes/Button',
+  title: 'Echoes Components/Button',
   argTypes: {
     size: { control: { type: 'select' }, options: Object.values(ButtonSize) },
     variety: { control: { type: 'select' }, options: Object.values(ButtonVariety) },

--- a/stories/ButtonIcon-stories.tsx
+++ b/stories/ButtonIcon-stories.tsx
@@ -29,7 +29,7 @@ import { iconsComponentsArgType } from './helpers/arg-types';
 
 const meta: Meta<typeof ButtonIcon> = {
   component: ButtonIcon,
-  title: 'Echoes/ButtonIcon',
+  title: 'Echoes Components/ButtonIcon',
   argTypes: {
     Icon: iconsComponentsArgType,
     size: { options: Object.values(ButtonSize) },

--- a/stories/Buttongroup-stories.tsx
+++ b/stories/Buttongroup-stories.tsx
@@ -24,7 +24,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof ButtonGroup> = {
   component: ButtonGroup,
-  title: 'Echoes/ButtonGroup',
+  title: 'Echoes Components/ButtonGroup',
   parameters: {
     controls: { exclude: ['children'] },
   },

--- a/stories/Card-stories.tsx
+++ b/stories/Card-stories.tsx
@@ -42,7 +42,7 @@ import {
 import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Card> = {
-  title: 'Echoes/Card',
+  title: 'Echoes Components/Card',
   component: Card,
   argTypes: {
     size: {

--- a/stories/Checkbox-stories.tsx
+++ b/stories/Checkbox-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
-  title: 'Echoes/Checkbox',
+  title: 'Echoes Components/Checkbox',
   parameters: {
     a11y: {
       config: {

--- a/stories/CheckboxGroup-stories.tsx
+++ b/stories/CheckboxGroup-stories.tsx
@@ -29,7 +29,7 @@ type CheckboxGroup = typeof CheckboxGroup;
 
 const meta: Meta<CheckboxGroup> = {
   component: CheckboxGroup,
-  title: 'Echoes/CheckboxGroup',
+  title: 'Echoes Components/CheckboxGroup',
   argTypes: {
     ...toTextControlArgTypes('label', 'messageInvalid', 'messageValid'),
   },

--- a/stories/Divider-stories.tsx
+++ b/stories/Divider-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Divider> = {
   component: Divider,
-  title: 'Echoes/Divider',
+  title: 'Echoes Components/Divider',
   argTypes: {
     isVertical: {
       control: 'boolean',

--- a/stories/Form-stories.tsx
+++ b/stories/Form-stories.tsx
@@ -33,7 +33,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Form> = {
   component: Form,
-  title: 'Echoes/Forms',
+  title: 'Echoes Patterns/Forms',
   argTypes: {},
   decorators: [basicWrapperDecorator],
 };

--- a/stories/Icons-stories.tsx
+++ b/stories/Icons-stories.tsx
@@ -27,7 +27,7 @@ import * as icons from '../src/components/icons';
 import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta = {
-  title: 'Echoes/Icons',
+  title: 'Echoes Components/Icons',
 };
 
 export default meta;

--- a/stories/LoadingContainer-stories.tsx
+++ b/stories/LoadingContainer-stories.tsx
@@ -25,7 +25,7 @@ import { Label, LoadingContainer, LoadingSkeleton, MessageCallout, RatingBadge }
 import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof LoadingContainer> = {
-  title: 'Echoes/LoadingContainer',
+  title: 'Echoes Components/LoadingContainer',
   component: LoadingContainer,
   decorators: [basicWrapperDecorator],
 };

--- a/stories/LoadingSkeleton-stories.tsx
+++ b/stories/LoadingSkeleton-stories.tsx
@@ -28,7 +28,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof LoadingSkeleton> = {
   component: LoadingSkeleton,
-  title: 'Echoes/LoadingSkeleton',
+  title: 'Echoes Components/LoadingSkeleton',
   argTypes: {},
   decorators: [basicWrapperDecorator],
   parameters: {

--- a/stories/Logos-stories.tsx
+++ b/stories/Logos-stories.tsx
@@ -32,7 +32,7 @@ import {
 import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta = {
-  title: 'Echoes/Logos',
+  title: 'Echoes Components/Logos',
   decorators: [basicWrapperDecorator],
   argTypes: {
     hasText: {

--- a/stories/MarginIndicator-stories.tsx
+++ b/stories/MarginIndicator-stories.tsx
@@ -26,7 +26,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof MarginIndicator> = {
   component: MarginIndicator,
-  title: 'Echoes/MarginIndicator',
+  title: 'Echoes Components/MarginIndicator',
   argTypes: {
     indicatorType: { control: { type: 'select' }, options: Object.values(MarginIndicatorType) },
   },

--- a/stories/Modal-stories.tsx
+++ b/stories/Modal-stories.tsx
@@ -37,7 +37,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Modal> = {
   component: Modal,
-  title: 'Echoes/Modal/Modal',
+  title: 'Echoes Components/Modal/Modal',
   parameters: {
     controls: { exclude: ['children'] },
   },

--- a/stories/ModalAlert-stories.tsx
+++ b/stories/ModalAlert-stories.tsx
@@ -26,7 +26,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof ModalAlert> = {
   component: ModalAlert,
-  title: 'Echoes/Modal/ModalAlert',
+  title: 'Echoes Components/Modal/ModalAlert',
   parameters: {
     controls: { exclude: ['children', 'secondaryButton', 'onOpenChange'] },
   },

--- a/stories/ModalForm-stories.tsx
+++ b/stories/ModalForm-stories.tsx
@@ -35,7 +35,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof ModalForm> = {
   component: ModalForm,
-  title: 'Echoes/Modal/ModalForm',
+  title: 'Echoes Components/Modal/ModalForm',
   parameters: {
     controls: { exclude: ['children', 'onReset', 'onSubmit', 'content', 'isDestructive'] },
   },

--- a/stories/Pagination-stories.tsx
+++ b/stories/Pagination-stories.tsx
@@ -24,7 +24,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Pagination> = {
   component: Pagination,
-  title: 'Echoes/Pagination',
+  title: 'Echoes Components/Pagination',
   argTypes: {},
   decorators: [basicWrapperDecorator],
 };

--- a/stories/Popover-stories.tsx
+++ b/stories/Popover-stories.tsx
@@ -24,7 +24,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Popover> = {
   component: Popover,
-  title: 'Echoes/Popover',
+  title: 'Echoes Components/Popover',
   parameters: {
     controls: { exclude: ['children'] },
   },

--- a/stories/RadioButtonGroup-stories.tsx
+++ b/stories/RadioButtonGroup-stories.tsx
@@ -24,7 +24,7 @@ import { formFieldsArgTypes } from './helpers/arg-types';
 
 const meta: Meta<typeof RadioButtonGroup> = {
   component: RadioButtonGroup,
-  title: 'Echoes/RadioButtonGroup',
+  title: 'Echoes Components/RadioButtonGroup',
   args: {
     isRequired: false,
   },

--- a/stories/SearchInput-stories.tsx
+++ b/stories/SearchInput-stories.tsx
@@ -25,7 +25,7 @@ import { toDisabledControlArgType } from './helpers/arg-types';
 
 const meta: Meta<typeof SearchInput> = {
   component: SearchInput,
-  title: 'Echoes/SearchInput',
+  title: 'Echoes Components/SearchInput',
   argTypes: {
     width: {
       control: { type: 'select' },

--- a/stories/SelectionCards-stories.tsx
+++ b/stories/SelectionCards-stories.tsx
@@ -24,7 +24,7 @@ import { FishtankIllustration } from './helpers/FishtankIllustration';
 
 const meta: Meta<typeof SelectionCards> = {
   component: SelectionCards,
-  title: 'Echoes/SelectionCards',
+  title: 'Echoes Components/SelectionCards',
   args: {},
 };
 

--- a/stories/Spinner-stories.tsx
+++ b/stories/Spinner-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Spinner> = {
   component: Spinner,
-  title: 'Echoes/Spinner',
+  title: 'Echoes Components/Spinner',
   parameters: {
     controls: { exclude: ['checked', 'onCheck'] },
   },

--- a/stories/Spotlight-stories.tsx
+++ b/stories/Spotlight-stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta<typeof Spotlight> = {
   },
   component: Spotlight,
   decorators: [basicWrapperDecorator],
-  title: 'Echoes/Spotlight',
+  title: 'Echoes Components/Spotlight',
 };
 
 export default meta;

--- a/stories/Table-stories.tsx
+++ b/stories/Table-stories.tsx
@@ -35,7 +35,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof Table> = {
   component: Table,
-  title: 'Echoes/Table',
+  title: 'Echoes Components/Table',
   parameters: {
     controls: { exclude: ['children'] },
   },

--- a/stories/TextArea-stories.tsx
+++ b/stories/TextArea-stories.tsx
@@ -25,7 +25,7 @@ import { formFieldsArgTypes } from './helpers/arg-types';
 
 const meta: Meta<typeof TextArea> = {
   component: TextArea,
-  title: 'Echoes/TextArea',
+  title: 'Echoes Components/TextArea',
   argTypes: formFieldsArgTypes,
   decorators: [basicWrapperDecorator],
 };

--- a/stories/TextInput-stories.tsx
+++ b/stories/TextInput-stories.tsx
@@ -32,7 +32,7 @@ import { formFieldsArgTypes, iconsElementsArgType } from './helpers/arg-types';
 
 const meta: Meta<typeof TextInput> = {
   component: TextInput,
-  title: 'Echoes/TextInput',
+  title: 'Echoes Components/TextInput',
   argTypes: {
     ...formFieldsArgTypes,
     prefix: iconsElementsArgType,

--- a/stories/ThemeProvider-stories.tsx
+++ b/stories/ThemeProvider-stories.tsx
@@ -39,7 +39,7 @@ function Background({ children, style }: ComponentProps<'div'>) {
 
 const meta: Meta<typeof ThemeProvider> = {
   component: ThemeProvider,
-  title: 'Echoes/ThemeProvider',
+  title: 'Echoes Components/ThemeProvider',
   argTypes: {
     asChild: { control: { type: 'boolean' } },
     theme: { control: { type: 'select' }, options: Object.values(Theme) },

--- a/stories/Toast-stories.tsx
+++ b/stories/Toast-stories.tsx
@@ -27,7 +27,7 @@ import { toDisabledControlArgType, toTextControlArgTypes } from './helpers/arg-t
 
 const meta: Meta<ToastParams> = {
   component: toast,
-  title: 'Echoes/Toast',
+  title: 'Echoes Components/Toast',
   argTypes: {
     ...toDisabledControlArgType('actions'),
     ...toTextControlArgTypes('title', 'description'),

--- a/stories/ToggleButtonGroup-stories.tsx
+++ b/stories/ToggleButtonGroup-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof ToggleButtonGroup> = {
   component: ToggleButtonGroup,
-  title: 'Echoes/ToggleButtonGroup',
+  title: 'Echoes Components/ToggleButtonGroup',
 
   parameters: {
     controls: { exclude: ['selected', 'options'] },

--- a/stories/ToggleTip-stories.tsx
+++ b/stories/ToggleTip-stories.tsx
@@ -24,7 +24,7 @@ import { basicWrapperDecorator } from './helpers/BasicWrapper';
 
 const meta: Meta<typeof ToggleTip> = {
   component: ToggleTip,
-  title: 'Echoes/ToggleTip',
+  title: 'Echoes Components/ToggleTip',
   parameters: {
     controls: { exclude: ['footer', 'extraContent'] },
   },

--- a/stories/Tooltip-stories.tsx
+++ b/stories/Tooltip-stories.tsx
@@ -27,7 +27,7 @@ import { cssVar } from '~utils/design-tokens';
 
 const meta: Meta<typeof Tooltip> = {
   component: Tooltip,
-  title: 'Echoes/Tooltip',
+  title: 'Echoes Components/Tooltip',
   parameters: {
     controls: { exclude: ['children'] },
   },

--- a/stories/badges/Badge-stories.tsx
+++ b/stories/badges/Badge-stories.tsx
@@ -40,7 +40,7 @@ const meta: Meta<typeof Badge> = {
     },
   },
 
-  title: 'Echoes/Badges/Badge',
+  title: 'Echoes Components/Badges/Badge',
 };
 
 export default meta;

--- a/stories/badges/BadgeCounter-stories.tsx
+++ b/stories/badges/BadgeCounter-stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta<typeof BadgeCounter> = {
     controls: { exclude: ['className'] },
   },
 
-  title: 'Echoes/Badges/BadgeCounter',
+  title: 'Echoes Components/Badges/BadgeCounter',
 };
 
 export default meta;

--- a/stories/badges/BadgeSeverity-stories.tsx
+++ b/stories/badges/BadgeSeverity-stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<typeof BadgeSeverity> = {
     severity: { options: Object.values(BadgeSeverityLevel) },
   },
 
-  title: 'Echoes/Badges/BadgeSeverity',
+  title: 'Echoes Components/Badges/BadgeSeverity',
 };
 
 export default meta;

--- a/stories/badges/RatingBadge-stories.tsx
+++ b/stories/badges/RatingBadge-stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof RatingBadge> = {
     controls: { exclude: ['className'] },
   },
 
-  title: 'Echoes/Badges/RatingBadge',
+  title: 'Echoes Components/Badges/RatingBadge',
 };
 
 export default meta;

--- a/stories/badges/RatingBadgeButton-stories.tsx
+++ b/stories/badges/RatingBadgeButton-stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof RatingBadgeButton> = {
     },
   },
 
-  title: 'Echoes/Badges/RatingBadgeButton',
+  title: 'Echoes Components/Badges/RatingBadgeButton',
 };
 
 export default meta;

--- a/stories/badges/RatingBadgeLink-stories.tsx
+++ b/stories/badges/RatingBadgeLink-stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof RatingBadgeLink> = {
     controls: { exclude: ['className'] },
   },
 
-  title: 'Echoes/Badges/RatingBadgeLink',
+  title: 'Echoes Components/Badges/RatingBadgeLink',
 };
 
 export default meta;

--- a/stories/dropdown-menu/DropdownMenu-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenu-stories.tsx
@@ -38,7 +38,7 @@ import { cssVar } from '~utils/design-tokens';
 
 const meta: Meta<typeof DropdownMenu> = {
   component: DropdownMenu,
-  title: 'Echoes/DropdownMenu',
+  title: 'Echoes Components/DropdownMenu',
   parameters: {
     controls: { exclude: ['children', 'id'] },
   },

--- a/stories/dropdown-menu/DropdownMenuItemButton-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemButton-stories.tsx
@@ -27,7 +27,7 @@ import { MenuButton } from '../helpers/MenuButton';
 const meta: Meta<typeof DropdownMenu.ItemButton> = {
   component: DropdownMenu.ItemButton,
   decorators: [basicWrapperDecorator],
-  title: 'Echoes/DropdownMenuItems/ItemButton',
+  title: 'Echoes Components/DropdownMenu/ItemButton',
   parameters: {
     controls: { exclude: ['onClick'] },
   },

--- a/stories/dropdown-menu/DropdownMenuItemButtonCheckable-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemButtonCheckable-stories.tsx
@@ -27,7 +27,7 @@ import { MenuButton } from '../helpers/MenuButton';
 const meta: Meta<typeof DropdownMenu.ItemButtonCheckable> = {
   component: DropdownMenu.ItemButtonCheckable,
   decorators: [basicWrapperDecorator],
-  title: 'Echoes/DropdownMenuItems/ItemButtonCheckable',
+  title: 'Echoes Components/DropdownMenu/ItemButtonCheckable',
   parameters: {
     controls: { exclude: ['onClick'] },
   },

--- a/stories/dropdown-menu/DropdownMenuItemButtonDestructive-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemButtonDestructive-stories.tsx
@@ -27,7 +27,7 @@ import { MenuButton } from '../helpers/MenuButton';
 const meta: Meta<typeof DropdownMenu.ItemButtonDestructive> = {
   component: DropdownMenu.ItemButtonDestructive,
   decorators: [basicWrapperDecorator],
-  title: 'Echoes/DropdownMenuItems/ItemButtonDestructive',
+  title: 'Echoes Components/DropdownMenu/ItemButtonDestructive',
   parameters: {
     controls: { exclude: ['onClick'] },
   },

--- a/stories/dropdown-menu/DropdownMenuItemLink-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemLink-stories.tsx
@@ -28,7 +28,7 @@ import { MenuButton } from '../helpers/MenuButton';
 const meta: Meta<typeof DropdownMenu.ItemLink> = {
   component: DropdownMenu.ItemLink,
   decorators: [basicWrapperDecorator],
-  title: 'Echoes/DropdownMenuItems/ItemLink',
+  title: 'Echoes Components/DropdownMenu/ItemLink',
   parameters: {
     controls: { exclude: ['onClick'] },
   },

--- a/stories/dropdown-menu/DropdownMenuItemLinkDownload-stories.tsx
+++ b/stories/dropdown-menu/DropdownMenuItemLinkDownload-stories.tsx
@@ -27,7 +27,7 @@ import { MenuButton } from '../helpers/MenuButton';
 const meta: Meta<typeof DropdownMenu.ItemLinkDownload> = {
   component: DropdownMenu.ItemLinkDownload,
   decorators: [basicWrapperDecorator],
-  title: 'Echoes/DropdownMenuItems/ItemLinkDownload',
+  title: 'Echoes Components/DropdownMenu/ItemLinkDownload',
   parameters: {
     controls: { exclude: ['onClick'] },
   },

--- a/stories/filters/FilterDropdown-stories.tsx
+++ b/stories/filters/FilterDropdown-stories.tsx
@@ -43,7 +43,7 @@ const meta: Meta<typeof FilterDropdown> = {
     ref: { control: false },
     selectedValues: { control: false },
   },
-  title: 'Echoes/Filters/FilterDropdown',
+  title: 'Echoes Patterns/Filters/FilterDropdown',
 };
 
 export default meta;

--- a/stories/filters/FilterDropdown-stories.tsx
+++ b/stories/filters/FilterDropdown-stories.tsx
@@ -19,14 +19,10 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useCallback, useMemo, useRef, useState } from 'react';
-import {
-  FilterDropdown,
-  FilterDropdownCategory,
-  FilterDropdownProps,
-  FilterDropdownTrigger,
-} from '../../src';
+import { useState } from 'react';
+import { FilterDropdown, FilterDropdownProps, FilterDropdownTrigger } from '../../src';
 import { basicWrapperDecorator } from '../helpers/BasicWrapper';
+import { useFilterDropdownCategories } from './filter-dropdown-helpers';
 
 const meta: Meta<typeof FilterDropdown> = {
   component: FilterDropdown,
@@ -49,133 +45,6 @@ const meta: Meta<typeof FilterDropdown> = {
 export default meta;
 
 type Story = StoryObj<typeof FilterDropdown>;
-
-const SEVERITY_ITEMS = [
-  { label: 'High', value: 'high', suffix: '42' },
-  { label: 'Medium', value: 'medium', suffix: '17' },
-  { label: 'Low', value: 'low', suffix: '8' },
-  { label: 'Info', value: 'info', suffix: '3' },
-];
-
-const TYPE_ITEMS = [
-  { label: 'Bug', value: 'bug', suffix: '24' },
-  { label: 'Vulnerability', value: 'vulnerability', suffix: '12' },
-  { label: 'Code Smell', value: 'code-smell', suffix: '34' },
-];
-
-const STATUS_ITEMS = [
-  { label: 'Open', value: 'open', suffix: '55' },
-  { label: 'Confirmed', value: 'confirmed', suffix: '11' },
-  { label: 'Resolved', value: 'resolved', suffix: '4' },
-];
-
-const ALL_ASSIGNEE_ITEMS = [
-  { label: 'Alice Martin', value: 'alice' },
-  { label: 'Bob Johnson', value: 'bob' },
-  { label: 'Carol Williams', value: 'carol' },
-  { label: 'David Brown', value: 'david' },
-  { label: 'Eve Davis', value: 'eve' },
-  { label: 'Frank Miller', value: 'frank' },
-  { label: 'Grace Wilson', value: 'grace' },
-  { label: 'Hank Moore', value: 'hank' },
-  { label: 'Iris Taylor', value: 'iris' },
-  { label: 'Jack Anderson', value: 'jack' },
-];
-
-function randomDelay(minMs: number, maxMs: number) {
-  return Math.random() * (maxMs - minMs) + minMs;
-}
-
-function withRandomCounts<T extends { label: string; value: string }>(
-  items: T[],
-): (T & { suffix: string })[] {
-  return items.map((item) => ({
-    ...item,
-    suffix: (Math.floor(Math.random() * 99) + 1).toString(),
-  }));
-}
-
-function DateRangeContent({ ref }: Readonly<{ ref?: React.Ref<HTMLInputElement> }>) {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', padding: '16px' }}>
-      <p style={{ margin: 0 }}>
-        This is a custom component rendered inside the right panel. Arrow keys navigate between
-        panels; interaction within is managed by the consumer.
-      </p>
-      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-        {'From'}
-        <input ref={ref} type="date" />
-      </label>
-      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-        {'To'}
-        <input type="date" />
-      </label>
-    </div>
-  );
-}
-
-/**
- * Builds the shared category set used by all stories:
- * - Severity: multi-select, sync items
- * - Type: single-select, sync items
- * - Status: multi-select, client-side search, sync items
- * - Assignee: multi-select, async items, server-side search
- * - Date Range: custom content
- */
-function useFilterDropdownCategories() {
-  const dateInputRef = useRef<HTMLInputElement>(null);
-  const [assigneeItems, setAssigneeItems] = useState<FilterDropdownCategory['items']>(undefined);
-
-  const handleCategorySelect = useCallback(
-    (label: string) => {
-      // Only trigger the async load on the first visit; subsequent visits show cached items.
-      if (label === 'Assignee' && assigneeItems === undefined) {
-        setTimeout(
-          () => setAssigneeItems(withRandomCounts(ALL_ASSIGNEE_ITEMS)),
-          randomDelay(1000, 3000),
-        );
-      }
-    },
-    [assigneeItems],
-  );
-
-  // Simulate a server-side search: keep current items visible while fetching,
-  // then replace with filtered results once resolved.
-  const handleAssigneeSearch = useCallback((query: string) => {
-    setTimeout(() => {
-      const matched = ALL_ASSIGNEE_ITEMS.filter(
-        (item) => !query || item.label.toLowerCase().includes(query.toLowerCase()),
-      );
-      setAssigneeItems(withRandomCounts(matched));
-    }, 500);
-  }, []);
-
-  const categories = useMemo<FilterDropdownCategory[]>(
-    () => [
-      { isMultiSelect: true, label: 'Severity', items: SEVERITY_ITEMS },
-      { isMultiSelect: false, label: 'Type', items: TYPE_ITEMS },
-      { isMultiSelect: true, isSearchable: true, label: 'Status', items: STATUS_ITEMS },
-      {
-        isMultiSelect: true,
-        isSearchable: true,
-        items: assigneeItems,
-        label: 'Assignee',
-        labelSearchPlaceholder: 'Search assignees…',
-        onSearch: handleAssigneeSearch,
-      },
-      {
-        content: <DateRangeContent ref={dateInputRef} />,
-        onFocusContent: () => {
-          dateInputRef.current?.focus();
-        },
-        label: 'Date Range',
-      },
-    ],
-    [assigneeItems, handleAssigneeSearch],
-  );
-
-  return { categories, onCategorySelect: handleCategorySelect };
-}
 
 function FilterDropdownStory(props: Readonly<FilterDropdownProps>) {
   const [selectedValues, setSelectedValues] = useState<string[]>([]);

--- a/stories/filters/FilterTag-stories.tsx
+++ b/stories/filters/FilterTag-stories.tsx
@@ -39,7 +39,7 @@ type Story = StoryObj<typeof FilterTag>;
 
 export const Default: Story = {
   args: {
-    children: 'Severity',
+    children: 'Duplications: < 3%',
     onDismiss: () => {},
   },
 };

--- a/stories/filters/FilterTag-stories.tsx
+++ b/stories/filters/FilterTag-stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof FilterTag> = {
     controls: { exclude: ['className', 'onDismiss'] },
   },
 
-  title: 'Echoes/Filters/FilterTag',
+  title: 'Echoes Patterns/Filters/FilterTag',
 };
 
 export default meta;

--- a/stories/filters/FilterToolbar-stories.tsx
+++ b/stories/filters/FilterToolbar-stories.tsx
@@ -22,17 +22,23 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import {
   Button,
+  ButtonIcon,
   Checkbox,
   DropdownMenu,
+  FilterDropdown,
+  FilterDropdownTrigger,
   FilterTag,
   IconChevronDown,
   IconFilter,
+  IconHome,
   SearchInput,
   Text,
+  ToggleButtonGroup,
   Toolbar,
   ToolbarProps,
 } from '../../src';
 import { basicWrapperDecorator } from '../helpers/BasicWrapper';
+import { FILTER_TAG_LABELS, useFilterDropdownCategories } from './filter-dropdown-helpers';
 
 const meta: Meta<typeof Toolbar> = {
   argTypes: {
@@ -54,8 +60,8 @@ export default meta;
 
 type Story = StoryObj<typeof Toolbar>;
 
-const SEVERITIES = ['High', 'Medium', 'Low'];
-const SORT_OPTIONS = ['Last updated', 'Name', 'Severity'];
+const EVENTS = ['Quality gate', 'Definition Change', 'Other'];
+const SORT_OPTIONS = ['Last updated', 'Name', 'Events'];
 
 function DefaultStory(props: Readonly<ToolbarProps>) {
   const {
@@ -70,20 +76,28 @@ function DefaultStory(props: Readonly<ToolbarProps>) {
 
   const [search, setSearch] = useState('');
   const [selectAll, setSelectAll] = useState<boolean | 'indeterminate'>('indeterminate');
-  const [selectedSeverities, setSelectedSeverities] = useState<Set<string>>(new Set(['High']));
+  const [selectedEvents, setSelectedEvents] = useState<Set<string>>(new Set(['Quality gate']));
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
   const [currentSort, setCurrentSort] = useState('Last updated');
+  const [scope, setScope] = useState('overall');
 
-  function toggleSeverity(severity: string) {
-    setSelectedSeverities((prev) => {
+  function toggleEvent(event: string) {
+    setSelectedEvents((prev) => {
       const next = new Set(prev);
-      if (next.has(severity)) {
-        next.delete(severity);
+      if (next.has(event)) {
+        next.delete(event);
       } else {
-        next.add(severity);
+        next.add(event);
       }
       return next;
     });
   }
+
+  function dismissValue(value: string) {
+    setSelectedValues((prev) => prev.filter((v) => v !== value));
+  }
+
+  const { categories, onCategorySelect } = useFilterDropdownCategories();
 
   return (
     <Toolbar
@@ -91,32 +105,62 @@ function DefaultStory(props: Readonly<ToolbarProps>) {
       datasetControls={
         datasetControls ? (
           <>
-            <Text>4 projects</Text>
-            <Button>Bulk action</Button>
+            <Text>
+              <b>4</b> projects
+            </Text>
+            <ButtonIcon Icon={IconHome} ariaLabel="Set homepage" />
           </>
         ) : undefined
       }
       filterControls={
         filterControls ? (
-          <DropdownMenu
-            items={SEVERITIES.map((severity) => (
-              <DropdownMenu.ItemButtonCheckable
-                isChecked={selectedSeverities.has(severity)}
-                key={severity}
-                onClick={() => toggleSeverity(severity)}>
-                {severity}
-              </DropdownMenu.ItemButtonCheckable>
-            ))}>
-            <Button prefix={<IconFilter />}>Filters</Button>
-          </DropdownMenu>
+          <>
+            <FilterDropdown
+              categories={categories}
+              onApply={setSelectedValues}
+              onCategorySelect={onCategorySelect}
+              onClear={() => setSelectedValues([])}
+              selectedValues={selectedValues}>
+              <FilterDropdownTrigger selectedCount={selectedValues.length}>
+                Facets Filters
+              </FilterDropdownTrigger>
+            </FilterDropdown>
+            <DropdownMenu
+              items={EVENTS.map((event) => (
+                <DropdownMenu.ItemButtonCheckable
+                  isChecked={selectedEvents.has(event)}
+                  key={event}
+                  onClick={() => toggleEvent(event)}>
+                  {event}
+                </DropdownMenu.ItemButtonCheckable>
+              ))}>
+              <Button prefix={<IconFilter />} suffix={<IconChevronDown />}>
+                Events
+              </Button>
+            </DropdownMenu>
+          </>
         ) : undefined
       }
-      filterTags={[...selectedSeverities].map((severity) => (
-        <FilterTag key={severity} onDismiss={() => toggleSeverity(severity)}>
-          {`Severity: ${severity}`}
-        </FilterTag>
-      ))}
-      onClearAll={onClearAll ? () => setSelectedSeverities(new Set()) : undefined}
+      filterTags={[
+        ...selectedValues.map((value) => (
+          <FilterTag key={value} onDismiss={() => dismissValue(value)}>
+            {FILTER_TAG_LABELS[value] ?? value}
+          </FilterTag>
+        )),
+        ...[...selectedEvents].map((event) => (
+          <FilterTag key={event} onDismiss={() => toggleEvent(event)}>
+            {`Events: ${event}`}
+          </FilterTag>
+        )),
+      ]}
+      onClearAll={
+        onClearAll
+          ? () => {
+              setSelectedValues([]);
+              setSelectedEvents(new Set());
+            }
+          : undefined
+      }
       searchInput={
         searchInput ? (
           <SearchInput
@@ -138,14 +182,24 @@ function DefaultStory(props: Readonly<ToolbarProps>) {
       }
       sortControls={
         sortControls ? (
-          <DropdownMenu
-            items={SORT_OPTIONS.map((option) => (
-              <DropdownMenu.ItemButton key={option} onClick={() => setCurrentSort(option)}>
-                {option}
-              </DropdownMenu.ItemButton>
-            ))}>
-            <Button suffix={<IconChevronDown />}>Sort: {currentSort}</Button>
-          </DropdownMenu>
+          <>
+            <DropdownMenu
+              items={SORT_OPTIONS.map((option) => (
+                <DropdownMenu.ItemButton key={option} onClick={() => setCurrentSort(option)}>
+                  {option}
+                </DropdownMenu.ItemButton>
+              ))}>
+              <Button suffix={<IconChevronDown />}>Sort by: {currentSort}</Button>
+            </DropdownMenu>
+            <ToggleButtonGroup
+              onChange={setScope}
+              options={[
+                { label: 'Overall code', value: 'overall' },
+                { label: 'New code', value: 'new' },
+              ]}
+              selected={scope}
+            />
+          </>
         ) : undefined
       }
     />

--- a/stories/filters/FilterToolbar-stories.tsx
+++ b/stories/filters/FilterToolbar-stories.tsx
@@ -1,0 +1,168 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import {
+  Button,
+  Checkbox,
+  DropdownMenu,
+  FilterTag,
+  IconChevronDown,
+  IconFilter,
+  SearchInput,
+  Text,
+  Toolbar,
+  ToolbarProps,
+} from '../../src';
+import { basicWrapperDecorator } from '../helpers/BasicWrapper';
+
+const meta: Meta<typeof Toolbar> = {
+  argTypes: {
+    datasetControls: { control: 'boolean' },
+    filterControls: { control: 'boolean' },
+    filterTags: { control: false },
+    onClearAll: { control: 'boolean' },
+    ref: { control: false },
+    searchInput: { control: 'boolean' },
+    selectAllControl: { control: 'boolean' },
+    sortControls: { control: 'boolean' },
+  },
+  component: Toolbar,
+  decorators: [basicWrapperDecorator],
+  title: 'Echoes Patterns/Filters',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Toolbar>;
+
+const SEVERITIES = ['High', 'Medium', 'Low'];
+const SORT_OPTIONS = ['Last updated', 'Name', 'Severity'];
+
+function DefaultStory(props: Readonly<ToolbarProps>) {
+  const {
+    datasetControls,
+    filterControls,
+    onClearAll,
+    searchInput,
+    selectAllControl,
+    sortControls,
+    ...toolbarProps
+  } = props;
+
+  const [search, setSearch] = useState('');
+  const [selectAll, setSelectAll] = useState<boolean | 'indeterminate'>('indeterminate');
+  const [selectedSeverities, setSelectedSeverities] = useState<Set<string>>(new Set(['High']));
+  const [currentSort, setCurrentSort] = useState('Last updated');
+
+  function toggleSeverity(severity: string) {
+    setSelectedSeverities((prev) => {
+      const next = new Set(prev);
+      if (next.has(severity)) {
+        next.delete(severity);
+      } else {
+        next.add(severity);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <Toolbar
+      {...toolbarProps}
+      datasetControls={
+        datasetControls ? (
+          <>
+            <Text>4 projects</Text>
+            <Button>Bulk action</Button>
+          </>
+        ) : undefined
+      }
+      filterControls={
+        filterControls ? (
+          <DropdownMenu
+            items={SEVERITIES.map((severity) => (
+              <DropdownMenu.ItemButtonCheckable
+                isChecked={selectedSeverities.has(severity)}
+                key={severity}
+                onClick={() => toggleSeverity(severity)}>
+                {severity}
+              </DropdownMenu.ItemButtonCheckable>
+            ))}>
+            <Button prefix={<IconFilter />}>Filters</Button>
+          </DropdownMenu>
+        ) : undefined
+      }
+      filterTags={[...selectedSeverities].map((severity) => (
+        <FilterTag key={severity} onDismiss={() => toggleSeverity(severity)}>
+          {`Severity: ${severity}`}
+        </FilterTag>
+      ))}
+      onClearAll={onClearAll ? () => setSelectedSeverities(new Set()) : undefined}
+      searchInput={
+        searchInput ? (
+          <SearchInput
+            onChange={setSearch}
+            placeholderLabel="Search issues"
+            value={search}
+            width="large"
+          />
+        ) : undefined
+      }
+      selectAllControl={
+        selectAllControl ? (
+          <Checkbox
+            ariaLabel="Select all"
+            checked={selectAll}
+            onCheck={(checked) => setSelectAll(checked)}
+          />
+        ) : undefined
+      }
+      sortControls={
+        sortControls ? (
+          <DropdownMenu
+            items={SORT_OPTIONS.map((option) => (
+              <DropdownMenu.ItemButton key={option} onClick={() => setCurrentSort(option)}>
+                {option}
+              </DropdownMenu.ItemButton>
+            ))}>
+            <Button suffix={<IconChevronDown />}>Sort: {currentSort}</Button>
+          </DropdownMenu>
+        ) : undefined
+      }
+    />
+  );
+}
+
+export const Default: Story = {
+  args: {
+    ariaLabel: 'Issue filters and actions',
+    datasetControls: true,
+    filterControls: true,
+    labelClearAll: 'Clear filters',
+    labelEmptyFilterTags: 'No filters applied',
+    onClearAll: true as unknown as () => void,
+    searchInput: true,
+    selectAllControl: true,
+    sortControls: true,
+  },
+  render: (args) => <DefaultStory {...args} />,
+};

--- a/stories/filters/filter-dropdown-helpers.tsx
+++ b/stories/filters/filter-dropdown-helpers.tsx
@@ -1,0 +1,245 @@
+/*
+ * Echoes React
+ * Copyright (C) 2023-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { Ref, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  FilterDropdownCategory,
+  IndicatorDuplication,
+  IndicatorDuplicationRating,
+  IndicatorSize,
+  RatingBadge,
+  RatingBadgeRating,
+  RatingBadgeSize,
+} from '../../src';
+
+const SECURITY_ITEMS = [
+  {
+    label: '≥ 0 info issues',
+    value: 'security-a',
+    suffix: '88',
+    prefix: <RatingBadge rating={RatingBadgeRating.A} size={RatingBadgeSize.ExtraSmall} />,
+  },
+  {
+    label: '≥ 1 low issue',
+    value: 'security-b',
+    suffix: '0',
+    prefix: <RatingBadge rating={RatingBadgeRating.B} size={RatingBadgeSize.ExtraSmall} />,
+  },
+  {
+    label: '≥ 1 medium issue',
+    value: 'security-c',
+    suffix: '0',
+    prefix: <RatingBadge rating={RatingBadgeRating.C} size={RatingBadgeSize.ExtraSmall} />,
+  },
+  {
+    label: '≥ 1 high issue',
+    value: 'security-d',
+    suffix: '0',
+    prefix: <RatingBadge rating={RatingBadgeRating.D} size={RatingBadgeSize.ExtraSmall} />,
+  },
+  {
+    label: '≥ 1 blocker issue',
+    value: 'security-e',
+    suffix: '0',
+    prefix: <RatingBadge rating={RatingBadgeRating.E} size={RatingBadgeSize.ExtraSmall} />,
+  },
+];
+
+const DUPLICATION_ITEMS = [
+  {
+    label: '< 3%',
+    value: 'duplication-lt-3',
+    suffix: '88',
+    prefix: (
+      <IndicatorDuplication rating={IndicatorDuplicationRating.A} size={IndicatorSize.Small} />
+    ),
+  },
+  {
+    label: '3% - 5%',
+    value: 'duplication-3-5',
+    suffix: '0',
+    prefix: (
+      <IndicatorDuplication rating={IndicatorDuplicationRating.B} size={IndicatorSize.Small} />
+    ),
+  },
+  {
+    label: '5% - 10%',
+    value: 'duplication-5-10',
+    suffix: '0',
+    prefix: (
+      <IndicatorDuplication rating={IndicatorDuplicationRating.C} size={IndicatorSize.Small} />
+    ),
+  },
+  {
+    label: '10% - 20%',
+    value: 'duplication-10-20',
+    suffix: '0',
+    prefix: (
+      <IndicatorDuplication rating={IndicatorDuplicationRating.D} size={IndicatorSize.Small} />
+    ),
+  },
+  {
+    label: '> 20%',
+    value: 'duplication-gt-20',
+    suffix: '0',
+    prefix: (
+      <IndicatorDuplication rating={IndicatorDuplicationRating.E} size={IndicatorSize.Small} />
+    ),
+  },
+  {
+    label: 'No data',
+    value: 'duplication-no-data',
+    suffix: '8',
+    prefix: <IndicatorDuplication rating={undefined} size={IndicatorSize.Small} />,
+  },
+];
+
+const TYPE_ITEMS = [
+  { label: 'Project', value: 'project', suffix: '42' },
+  { label: 'Application', value: 'application', suffix: '17' },
+];
+
+const ALL_ASSIGNEE_ITEMS = [
+  { label: 'Alice Martin', value: 'alice' },
+  { label: 'Bob Johnson', value: 'bob' },
+  { label: 'Carol Williams', value: 'carol' },
+  { label: 'David Brown', value: 'david' },
+  { label: 'Eve Davis', value: 'eve' },
+  { label: 'Frank Miller', value: 'frank' },
+  { label: 'Grace Wilson', value: 'grace' },
+  { label: 'Hank Moore', value: 'hank' },
+  { label: 'Iris Taylor', value: 'iris' },
+  { label: 'Jack Anderson', value: 'jack' },
+];
+
+export const ALL_FILTER_ITEMS = [
+  ...SECURITY_ITEMS,
+  ...DUPLICATION_ITEMS,
+  ...TYPE_ITEMS,
+  ...ALL_ASSIGNEE_ITEMS,
+];
+
+const CATEGORIZED_ITEMS: Array<{
+  category: string;
+  items: Array<{ label: string; value: string }>;
+}> = [
+  { category: 'Security', items: SECURITY_ITEMS },
+  { category: 'Duplications', items: DUPLICATION_ITEMS },
+  { category: 'Type', items: TYPE_ITEMS },
+  { category: 'Assignee', items: ALL_ASSIGNEE_ITEMS },
+];
+
+export const FILTER_TAG_LABELS: Record<string, string> = Object.fromEntries(
+  CATEGORIZED_ITEMS.flatMap(({ category, items }) =>
+    items.map(({ value, label }) => [value, `${category}: ${label}`]),
+  ),
+);
+
+function randomDelay(minMs: number, maxMs: number) {
+  return Math.random() * (maxMs - minMs) + minMs;
+}
+
+function withRandomCounts<T extends { label: string; value: string }>(
+  items: T[],
+): (T & { suffix: string })[] {
+  return items.map((item) => ({
+    ...item,
+    suffix: (Math.floor(Math.random() * 99) + 1).toString(),
+  }));
+}
+
+function DateRangeContent({ ref }: Readonly<{ ref?: Ref<HTMLInputElement> }>) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', padding: '16px' }}>
+      <p style={{ margin: 0 }}>
+        This is a custom component rendered inside the right panel. Arrow keys navigate between
+        panels; interaction within is managed by the consumer.
+      </p>
+      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {'From'}
+        <input ref={ref} type="date" />
+      </label>
+      <label style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+        {'To'}
+        <input type="date" />
+      </label>
+    </div>
+  );
+}
+
+/**
+ * Builds the shared category set used by filter stories:
+ * - Duplication: multi-select, sync items with duplication indicator prefix
+ * - Type: single-select, sync items
+ * - Status: multi-select, client-side search, sync items
+ * - Assignee: multi-select, async items, server-side search
+ * - Date Range: custom content
+ */
+export function useFilterDropdownCategories() {
+  const dateInputRef = useRef<HTMLInputElement>(null);
+  const [assigneeItems, setAssigneeItems] = useState<FilterDropdownCategory['items']>(undefined);
+
+  const handleCategorySelect = useCallback(
+    (label: string) => {
+      if (label === 'Assignee' && assigneeItems === undefined) {
+        setTimeout(
+          () => setAssigneeItems(withRandomCounts(ALL_ASSIGNEE_ITEMS)),
+          randomDelay(1000, 3000),
+        );
+      }
+    },
+    [assigneeItems],
+  );
+
+  const handleAssigneeSearch = useCallback((query: string) => {
+    setTimeout(() => {
+      const matched = ALL_ASSIGNEE_ITEMS.filter(
+        (item) => !query || item.label.toLowerCase().includes(query.toLowerCase()),
+      );
+      setAssigneeItems(withRandomCounts(matched));
+    }, 500);
+  }, []);
+
+  const categories = useMemo<FilterDropdownCategory[]>(
+    () => [
+      { isMultiSelect: true, label: 'Security', items: SECURITY_ITEMS },
+      { isMultiSelect: true, label: 'Duplications', items: DUPLICATION_ITEMS },
+      { isMultiSelect: false, label: 'Type', items: TYPE_ITEMS },
+      {
+        isMultiSelect: true,
+        isSearchable: true,
+        items: assigneeItems,
+        label: 'Assignee',
+        labelSearchPlaceholder: 'Search assignees…',
+        onSearch: handleAssigneeSearch,
+      },
+      {
+        content: <DateRangeContent ref={dateInputRef} />,
+        onFocusContent: () => {
+          dateInputRef.current?.focus();
+        },
+        label: 'Date Range',
+      },
+    ],
+    [assigneeItems, handleAssigneeSearch],
+  );
+
+  return { categories, onCategorySelect: handleCategorySelect };
+}

--- a/stories/indicators/IndicatorCoverage-stories.tsx
+++ b/stories/indicators/IndicatorCoverage-stories.tsx
@@ -27,7 +27,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof IndicatorCoverage> = {
   component: IndicatorCoverage,
-  title: 'Echoes/indicators/Coverage',
+  title: 'Echoes Components/Indicators/Coverage',
   decorators: [basicWrapperDecorator],
   argTypes: {
     rating: {

--- a/stories/indicators/IndicatorDuplication-stories.tsx
+++ b/stories/indicators/IndicatorDuplication-stories.tsx
@@ -26,7 +26,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof IndicatorDuplication> = {
   component: IndicatorDuplication,
-  title: 'Echoes/indicators/Duplication',
+  title: 'Echoes Components/Indicators/Duplication',
   decorators: [basicWrapperDecorator],
   argTypes: {
     rating: {

--- a/stories/layout/Banner-stories.tsx
+++ b/stories/layout/Banner-stories.tsx
@@ -34,7 +34,7 @@ import { minWidthBodyDecorator } from '../helpers/decorators';
 
 const meta: Meta<typeof Layout.Banner> = {
   component: Layout.Banner,
-  title: 'Echoes/Layout/Banner',
+  title: 'Echoes Patterns/Layout/Banner',
 
   argTypes: {
     announcementMode: {

--- a/stories/layout/ContentHeader-stories.tsx
+++ b/stories/layout/ContentHeader-stories.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../src';
 
 const meta: Meta<typeof Layout.ContentHeader | typeof Layout.ContentHeader.Title> = {
-  title: 'Echoes/Layout/ContentHeader',
+  title: 'Echoes Patterns/Layout/ContentHeader',
   argTypes: {
     actions: {
       control: { type: 'boolean' },

--- a/stories/layout/GlobalNavigation-stories.tsx
+++ b/stories/layout/GlobalNavigation-stories.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../src';
 
 const meta: Meta<typeof Layout.GlobalNavigation> = {
-  title: 'Echoes/Layout/GlobalNavigation',
+  title: 'Echoes Patterns/Layout/GlobalNavigation',
   component: Layout.GlobalNavigation,
   argTypes: {
     children: {

--- a/stories/layout/Layout-stories.tsx
+++ b/stories/layout/Layout-stories.tsx
@@ -51,7 +51,7 @@ import { PageHeaderScrollBehavior } from '../../src/components/layout/header/com
 
 const meta: Meta = {
   component: Layout,
-  title: 'Echoes/Layout',
+  title: 'Echoes Patterns/Layout',
   parameters: {
     layout: 'fullscreen',
   },

--- a/stories/layout/PageHeader-stories.tsx
+++ b/stories/layout/PageHeader-stories.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../src';
 
 const meta: Meta<typeof Layout.PageHeader | typeof Layout.PageHeader.Title> = {
-  title: 'Echoes/Layout/PageHeader',
+  title: 'Echoes Patterns/Layout/PageHeader',
   argTypes: {
     actions: {
       control: { type: 'boolean' },

--- a/stories/layout/sidebar-navigation/SidebarNavigation-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigation-stories.tsx
@@ -47,7 +47,7 @@ import {
 
 const meta: Meta<typeof Layout.SidebarNavigation> = {
   component: Layout.SidebarNavigation,
-  title: 'Echoes/Layout/SidebarNavigation',
+  title: 'Echoes Patterns/Layout/SidebarNavigation',
   parameters: {
     layout: 'fullscreen',
   },

--- a/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
@@ -49,7 +49,7 @@ const accordionChildrenWithIcon = (
 );
 
 const meta: Meta<typeof Layout.SidebarNavigation.AccordionItem> = {
-  title: 'Echoes/Layout/SidebarNavigation/AccordionItem',
+  title: 'Echoes Patterns/Layout/SidebarNavigation/AccordionItem',
   component: Layout.SidebarNavigation.AccordionItem,
   argTypes: {
     isDefaultOpen: {

--- a/stories/layout/sidebar-navigation/SidebarNavigationFooterPromotionCard-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationFooterPromotionCard-stories.tsx
@@ -24,7 +24,7 @@ import { Badge, Button, ButtonGroup, Layout } from '../../../src';
 import { basicWrapperDecorator } from '../../helpers/BasicWrapper';
 
 const meta: Meta = {
-  title: 'Echoes/Layout/SidebarNavigation/Footer/PromotionCard',
+  title: 'Echoes Patterns/Layout/SidebarNavigation/Footer/PromotionCard',
   component: Layout.SidebarNavigation.Footer.PromotionCard,
   decorators: [basicWrapperDecorator],
 };

--- a/stories/layout/sidebar-navigation/SidebarNavigationGroup-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationGroup-stories.tsx
@@ -24,7 +24,7 @@ import { IconDirectory, Layout } from '../../../src';
 import { basicWrapperDecorator } from '../../helpers/BasicWrapper';
 
 const meta: Meta = {
-  title: 'Echoes/Layout/SidebarNavigation/Group',
+  title: 'Echoes Patterns/Layout/SidebarNavigation/Group',
   component: Layout.SidebarNavigation.Group,
   decorators: [
     (Story) => (

--- a/stories/layout/sidebar-navigation/SidebarNavigationHeader-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationHeader-stories.tsx
@@ -24,7 +24,7 @@ import { cssVar, DropdownMenu, Layout } from '../../../src';
 import { basicWrapperDecorator } from '../../helpers/BasicWrapper';
 
 const meta: Meta = {
-  title: 'Echoes/Layout/SidebarNavigation/Header',
+  title: 'Echoes Patterns/Layout/SidebarNavigation/Header',
   component: Layout.SidebarNavigation.Header,
   decorators: [
     (Story) => (

--- a/stories/layout/sidebar-navigation/SidebarNavigationItem-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationItem-stories.tsx
@@ -24,7 +24,7 @@ import { Badge, IconBranch, Layout } from '../../../src';
 import { basicWrapperDecorator } from '../../helpers/BasicWrapper';
 
 const meta: Meta = {
-  title: 'Echoes/Layout/SidebarNavigation/Item',
+  title: 'Echoes Patterns/Layout/SidebarNavigation/Item',
   component: Layout.SidebarNavigation.Item,
   decorators: [
     (Story) => (

--- a/stories/link/Link-stories.tsx
+++ b/stories/link/Link-stories.tsx
@@ -25,7 +25,7 @@ import { toDisabledControlArgType } from '../helpers/arg-types';
 
 const meta: Meta<typeof LinkComp> = {
   component: LinkComp,
-  title: 'Echoes/Link/Link',
+  title: 'Echoes Components/Link/Link',
   argTypes: {
     highlight: {
       control: {

--- a/stories/link/LinkStandalone-stories.tsx
+++ b/stories/link/LinkStandalone-stories.tsx
@@ -30,7 +30,7 @@ import { toDisabledControlArgType } from '../helpers/arg-types';
 
 const meta: Meta<typeof LinkStandaloneComp> = {
   component: LinkStandaloneComp,
-  title: 'Echoes/Link/LinkStandalone',
+  title: 'Echoes Components/Link/LinkStandalone',
   argTypes: {
     isDiscreet: {
       control: {

--- a/stories/message/MessageCallout-stories.tsx
+++ b/stories/message/MessageCallout-stories.tsx
@@ -24,15 +24,15 @@ import { useCallback, useState } from 'react';
 import {
   Button,
   ButtonVariety,
+  LiveRegionAnnouncementMode,
   MessageCallout,
   MessageVariety,
-  LiveRegionAnnouncementMode,
 } from '../../src';
 import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof MessageCallout> = {
   component: MessageCallout,
-  title: 'Echoes/Messages/MessageCallout',
+  title: 'Echoes Components/Messages/MessageCallout',
   argTypes: {
     announcementMode: {
       control: { type: 'select' },

--- a/stories/message/MessageInline-stories.tsx
+++ b/stories/message/MessageInline-stories.tsx
@@ -21,16 +21,16 @@
 /* eslint-disable no-console */
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
+  LiveRegionAnnouncementMode,
   MessageInline,
   MessageInlineSize,
   MessageVariety,
-  LiveRegionAnnouncementMode,
 } from '../../src';
 import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof MessageInline> = {
   component: MessageInline,
-  title: 'Echoes/Messages/MessageInline',
+  title: 'Echoes Components/Messages/MessageInline',
   argTypes: {
     announcementMode: {
       control: { type: 'select' },

--- a/stories/promoted-section/PromotedSection-stories.tsx
+++ b/stories/promoted-section/PromotedSection-stories.tsx
@@ -53,7 +53,7 @@ const meta: Meta<typeof PromotedSection> = {
     },
   },
 
-  title: 'Echoes/PromotedSection',
+  title: 'Echoes Components/PromotedSection',
 };
 
 export default meta;

--- a/stories/select/Select-stories.tsx
+++ b/stories/select/Select-stories.tsx
@@ -30,7 +30,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof Select> = {
   component: Select,
-  title: 'Echoes/Select/Select',
+  title: 'Echoes Components/Select/Select',
   args: {
     width: 'large',
   },

--- a/stories/select/SelectAsync-stories.tsx
+++ b/stories/select/SelectAsync-stories.tsx
@@ -29,7 +29,7 @@ import {
 
 const meta: Meta<typeof SelectAsync> = {
   component: SelectAsync,
-  title: 'Echoes/Select/SelectAsync',
+  title: 'Echoes Components/Select/SelectAsync',
   argTypes: {
     ...formFieldsArgTypes,
     valueIcon: iconsElementsArgType,

--- a/stories/toolbar/Toolbar-stories.tsx
+++ b/stories/toolbar/Toolbar-stories.tsx
@@ -18,151 +18,119 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import styled from '@emotion/styled';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
-import {
-  Button,
-  Checkbox,
-  DropdownMenu,
-  FilterTag,
-  IconChevronDown,
-  IconFilter,
-  SearchInput,
-  Text,
-  Toolbar,
-  ToolbarProps,
-} from '../../src';
+import { cssVar, Toolbar } from '../../src';
 import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
-const meta: Meta<typeof Toolbar> = {
+interface SlotArgs {
+  ariaLabel: string;
+  datasetControls: number;
+  filterControls: number;
+  filterTags: number;
+  onClearAll: boolean;
+  searchInput: boolean;
+  selectAllControl: boolean;
+  sortControls: number;
+}
+
+const meta: Meta<SlotArgs> = {
   argTypes: {
-    datasetControls: { control: 'boolean' },
-    filterControls: { control: 'boolean' },
-    filterTags: { control: false },
+    ariaLabel: { control: 'text' },
+    datasetControls: { control: { type: 'number', min: 0, max: 5 } },
+    filterControls: { control: { type: 'number', min: 0, max: 5 } },
+    filterTags: { control: { type: 'number', min: 0, max: 5 } },
     onClearAll: { control: 'boolean' },
-    ref: { control: false },
     searchInput: { control: 'boolean' },
     selectAllControl: { control: 'boolean' },
-    sortControls: { control: 'boolean' },
+    sortControls: { control: { type: 'number', min: 0, max: 5 } },
   },
+  // @ts-expect-error -- SlotArgs intentionally replaces ToolbarProps for story controls
   component: Toolbar,
   decorators: [basicWrapperDecorator],
-  title: 'Echoes/Toolbar',
+  title: 'Echoes Components/Toolbar',
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Toolbar>;
+type Story = StoryObj<SlotArgs>;
 
-const SEVERITIES = ['High', 'Medium', 'Low'];
-const SORT_OPTIONS = ['Last updated', 'Name', 'Severity'];
-
-function DefaultStory(props: Readonly<ToolbarProps>) {
-  const {
+export const Default: Story = {
+  args: {
+    ariaLabel: 'Toolbar slots overview',
+    datasetControls: 1,
+    filterControls: 2,
+    filterTags: 2,
+    onClearAll: true,
+    searchInput: true,
+    selectAllControl: true,
+    sortControls: 1,
+  },
+  render: ({
+    ariaLabel,
     datasetControls,
     filterControls,
+    filterTags,
     onClearAll,
     searchInput,
     selectAllControl,
     sortControls,
-    ...toolbarProps
-  } = props;
-
-  const [search, setSearch] = useState('');
-  const [selectAll, setSelectAll] = useState<boolean | 'indeterminate'>('indeterminate');
-  const [selectedSeverities, setSelectedSeverities] = useState<Set<string>>(new Set(['High']));
-  const [currentSort, setCurrentSort] = useState('Last updated');
-
-  function toggleSeverity(severity: string) {
-    setSelectedSeverities((prev) => {
-      const next = new Set(prev);
-      if (next.has(severity)) {
-        next.delete(severity);
-      } else {
-        next.add(severity);
-      }
-      return next;
-    });
-  }
-
-  return (
+    ...props
+  }) => (
     <Toolbar
-      {...toolbarProps}
+      ariaLabel={ariaLabel}
       datasetControls={
-        datasetControls ? (
-          <>
-            <Text>4 projects</Text>
-            <Button>Bulk action</Button>
-          </>
+        datasetControls > 0 ? (
+          <>{makeSlots(datasetControls, '#b39ddb', 'datasetControls')}</>
         ) : undefined
       }
       filterControls={
-        filterControls ? (
-          <DropdownMenu
-            items={SEVERITIES.map((severity) => (
-              <DropdownMenu.ItemButtonCheckable
-                isChecked={selectedSeverities.has(severity)}
-                key={severity}
-                onClick={() => toggleSeverity(severity)}>
-                {severity}
-              </DropdownMenu.ItemButtonCheckable>
-            ))}>
-            <Button prefix={<IconFilter />}>Filters</Button>
-          </DropdownMenu>
+        filterControls > 0 ? (
+          <>{makeSlots(filterControls, '#ffcc80', 'filterControls')}</>
         ) : undefined
       }
-      filterTags={[...selectedSeverities].map((severity) => (
-        <FilterTag key={severity} onDismiss={() => toggleSeverity(severity)}>
-          {`Severity: ${severity}`}
-        </FilterTag>
-      ))}
-      onClearAll={onClearAll ? () => setSelectedSeverities(new Set()) : undefined}
+      filterTags={makeSlots(filterTags, '#90caf9', 'filterTags')}
+      onClearAll={onClearAll && filterTags > 0 ? () => {} : undefined}
       searchInput={
         searchInput ? (
-          <SearchInput
-            onChange={setSearch}
-            placeholderLabel="Search issues"
-            value={search}
-            width="large"
-          />
+          <SlotBlock color="#a5d6a7" style={{ width: '160px' }}>
+            searchInput
+          </SlotBlock>
         ) : undefined
       }
       selectAllControl={
-        selectAllControl ? (
-          <Checkbox
-            ariaLabel="Select all"
-            checked={selectAll}
-            onCheck={(checked) => setSelectAll(checked)}
-          />
-        ) : undefined
+        selectAllControl ? <SlotBlock color="#ef9a9a">selectAllControl</SlotBlock> : undefined
       }
       sortControls={
-        sortControls ? (
-          <DropdownMenu
-            items={SORT_OPTIONS.map((option) => (
-              <DropdownMenu.ItemButton key={option} onClick={() => setCurrentSort(option)}>
-                {option}
-              </DropdownMenu.ItemButton>
-            ))}>
-            <Button suffix={<IconChevronDown />}>Sort: {currentSort}</Button>
-          </DropdownMenu>
-        ) : undefined
+        sortControls > 0 ? <>{makeSlots(sortControls, '#ffe082', 'sortControls')}</> : undefined
       }
+      {...props}
     />
-  );
-}
-
-export const Default: Story = {
-  args: {
-    ariaLabel: 'Issue filters and actions',
-    datasetControls: true,
-    filterControls: true,
-    labelClearAll: 'Clear filters',
-    labelEmptyFilterTags: 'No filters applied',
-    onClearAll: true as unknown as () => void,
-    searchInput: true,
-    selectAllControl: true,
-    sortControls: true,
-  },
-  render: (args) => <DefaultStory {...args} />,
+  ),
 };
+
+const SlotBlock = styled.div<{ color: string }>`
+  align-items: center;
+  background-color: ${({ color }) => color}33;
+  border: 2px solid ${({ color }) => color};
+  border-radius: ${cssVar('border-radius-200')};
+
+  font: ${cssVar('typography-code-default')};
+  color: ${cssVar('color-text-default')};
+
+  display: flex;
+  height: ${cssVar('dimension-height-800')};
+  justify-content: center;
+  padding: 0 ${cssVar('dimension-space-100')};
+  white-space: nowrap;
+`;
+
+SlotBlock.displayName = 'SlotBlock';
+
+function makeSlots(count: number, color: string, label: string) {
+  return Array.from({ length: count }, (_, i) => (
+    <SlotBlock color={color} key={i}>
+      {label} {i + 1}
+    </SlotBlock>
+  ));
+}

--- a/stories/typography/Display-stories.tsx
+++ b/stories/typography/Display-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof Display> = {
   component: Display,
-  title: 'Echoes/Typography/Display',
+  title: 'Echoes Components/Typography/Display',
   argTypes: {
     as: { control: { type: 'select' }, options: ['span', 'p', 'div'] },
   },

--- a/stories/typography/Heading-stories.tsx
+++ b/stories/typography/Heading-stories.tsx
@@ -26,7 +26,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof Heading> = {
   component: Heading,
-  title: 'Echoes/Typography/Heading',
+  title: 'Echoes Components/Typography/Heading',
   argTypes: {
     size: { control: { type: 'select' }, options: [...Object.values(HeadingSize), undefined] },
   },

--- a/stories/typography/HelperText-stories.tsx
+++ b/stories/typography/HelperText-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof HelperText> = {
   component: HelperText,
-  title: 'Echoes/Typography/HelperText',
+  title: 'Echoes Components/Typography/HelperText',
   decorators: [basicWrapperDecorator],
 };
 

--- a/stories/typography/Label-stories.tsx
+++ b/stories/typography/Label-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof Label> = {
   component: Label,
-  title: 'Echoes/Typography/Label',
+  title: 'Echoes Components/Typography/Label',
   decorators: [basicWrapperDecorator],
 };
 

--- a/stories/typography/Text-stories.tsx
+++ b/stories/typography/Text-stories.tsx
@@ -25,7 +25,7 @@ import { basicWrapperDecorator } from '../helpers/BasicWrapper';
 
 const meta: Meta<typeof Text> = {
   component: Text,
-  title: 'Echoes/Typography/Text',
+  title: 'Echoes Components/Typography/Text',
   decorators: [basicWrapperDecorator],
 };
 


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **UI components:**
    - Added `max-height` to `FilterDropdown` styling using the new `filter-dropdown-sizes-max-height-default` token.
    - Updated `FilterDropdownTrigger` to include `IconFilter` by default.
- **Design tokens:**
    - Added `filter-dropdown-sizes-max-height-default` set to `600px` in `base.json`.
- **Storybook:**
    - Reorganized story titles into `Echoes Components` and `Echoes Patterns` categories.
    - Added `FilterToolbar` and `filter-dropdown-helpers` to support advanced filtering patterns.
    - Updated `Toolbar` stories to use slot-based controls for better pattern demonstration.
- **Refactoring:**
    - Added missing type annotation for `BADGE_SEVERITY_STYLES` to enforce `BadgeSeverityLevel` mapping.

<sub>This will update automatically on new commits.</sub>