### PR TITLE
ECHOES-1426 Prepare for version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonarsource/echoes-react",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/SonarSource/echoes-react"


### PR DESCRIPTION
## Summary
- bump `package.json` from `3.2.0` to `4.0.0`
- prepare the next Echoes major after the breaking sidebar navigation API changes already merged on `main`
