### PR TITLE
ECHOES-1430 Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,11 @@
 name: Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
-      release_version:
-        description: 'Version'
-        required: false
+      version:
+        description: 'Full version including build number, e.g. 1.2.3.456'
+        required: true
 
 jobs:
   release:
@@ -17,6 +15,7 @@ jobs:
       skipJavascriptReleasabilityChecks: false
       useNpmTrustedPublisher: true
       githubEnvironment: release
+      version: ${{ inputs.version }}
     permissions:
       id-token: write
       contents: write

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -21,6 +21,12 @@ For more details, refer to the [internal versioning strategy](https://docs.googl
     - Example: <https://github.com/SonarSource/echoes-react/releases/tag/v0.5.0>
   - click _Publish Release_
 
+- Trigger the release workflow
+  - Go to the [Release action tab](https://github.com/SonarSource/echoes-react/actions/workflows/release.yml)
+  - open the `run workflow` dropdown
+  - fill the version field (including build number)
+  - Click `run workflow`!
+
 - On the `main` branch, bump the [package version](https://github.com/SonarSource/echoes-react/blob/main/package.json#L3) for the next development iteration with `yarn version major|minor` and commit with message `Prepare for version x.y`.
 
 ## Release Process for Patch Versions


### PR DESCRIPTION
Updating to v7 actually included a breaking change:

https://github.com/SonarSource/gh-action_release/tree/7.0.0#migrating-from-v6-to-v7-draft-first-workflow_dispatch

We'll have to trigger the workflow manually :/ 