### PR TITLE
ECHOES-1023/add-controlled-state

### DIFF
--- a/src/components/layout/sidebar-navigation/SidebarNavigationAccordionItem.tsx
+++ b/src/components/layout/sidebar-navigation/SidebarNavigationAccordionItem.tsx
@@ -23,6 +23,7 @@ import styled from '@emotion/styled';
 import { ReactNode, Ref, useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import { TextNode } from '~types/utils';
+import { isDefined } from '~common/helpers/types';
 import { cssVar } from '~utils/design-tokens';
 import { IconChevronDown, IconChevronRight } from '../../icons';
 import { Tooltip } from '../../tooltip';
@@ -36,7 +37,7 @@ import {
 import { SidebarNavigationIconComponent } from './SidebarNavigationTypes';
 import { TOOLTIP_DELAY_IN_MS } from './utils';
 
-export interface SidebarNavigationAccordionItemProps {
+interface SidebarNavigationAccordionItemCommonProps {
   /**
    * ARIA label for the SidebarNavigationAccordionItem button.
    */
@@ -62,11 +63,6 @@ export interface SidebarNavigationAccordionItemProps {
    */
   Icon: SidebarNavigationIconComponent;
   /**
-   * Whether the accordion is open by default.
-   * @defaultValue false
-   */
-  isDefaultOpen?: boolean;
-  /**
    * The label for the SidebarNavigationAccordionItem.
    */
   label: TextNode;
@@ -78,6 +74,10 @@ export interface SidebarNavigationAccordionItemProps {
    * The onOpen callback is called when the accordion is opened.
    */
   onOpen?: VoidFunction;
+  /**
+   * Called with the next open state when the user toggles the accordion.
+   */
+  onOpenChange?: (isOpen: boolean) => void;
   /**
    * React ref forwarded to the root button element.
    */
@@ -94,6 +94,33 @@ export interface SidebarNavigationAccordionItemProps {
   suffix?: ReactNode;
 }
 
+interface SidebarNavigationAccordionItemControlledProps extends SidebarNavigationAccordionItemCommonProps {
+  /**
+   * The default open state is only available for uncontrolled usage.
+   */
+  isDefaultOpen?: never;
+  /**
+   * Whether the accordion is open. When provided, the accordion is controlled.
+   */
+  isOpen: boolean;
+}
+
+interface SidebarNavigationAccordionItemUncontrolledProps extends SidebarNavigationAccordionItemCommonProps {
+  /**
+   * Whether the accordion is open by default.
+   * @defaultValue false
+   */
+  isDefaultOpen?: boolean;
+  /**
+   * The current open state is only available for controlled usage.
+   */
+  isOpen?: never;
+}
+
+export type SidebarNavigationAccordionItemProps =
+  | SidebarNavigationAccordionItemControlledProps
+  | SidebarNavigationAccordionItemUncontrolledProps;
+
 export function SidebarNavigationAccordionItem(
   props: Readonly<SidebarNavigationAccordionItemProps>,
 ) {
@@ -103,16 +130,19 @@ export function SidebarNavigationAccordionItem(
     disableTooltip = false,
     Icon,
     isDefaultOpen = false,
+    isOpen,
     label,
     onClose,
     onOpen,
+    onOpenChange,
     ref,
     scrollLastChildIntoViewOnOpen,
     suffix,
     ...htmlProps
   } = props;
 
-  const [open, setOpen] = useState(isDefaultOpen);
+  const [internalOpen, setInternalOpen] = useState(isDefaultOpen);
+  const open = isDefined(isOpen) ? isOpen : internalOpen;
   const panelRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -126,18 +156,20 @@ export function SidebarNavigationAccordionItem(
   const accordionPanelId = `${accordionId}-panel`;
 
   const handleClick = useCallback(() => {
-    setOpen((open) => {
-      if (!open) {
-        onOpen?.();
+    const nextOpen = !open;
 
-        return true;
-      }
+    if (!isDefined(isOpen)) {
+      setInternalOpen(nextOpen);
+    }
 
+    onOpenChange?.(nextOpen);
+
+    if (nextOpen) {
+      onOpen?.();
+    } else {
       onClose?.();
-
-      return false;
-    });
-  }, [onOpen, onClose]);
+    }
+  }, [isOpen, onClose, onOpen, onOpenChange, open]);
 
   return (
     <AccordionWrapper>

--- a/src/components/layout/sidebar-navigation/__tests__/SidebarNavigationAccordionItem-test.tsx
+++ b/src/components/layout/sidebar-navigation/__tests__/SidebarNavigationAccordionItem-test.tsx
@@ -58,6 +58,10 @@ it('should expand hidden elements when clicked', async () => {
 it('should render uncontrolled and closed by default', () => {
   setupSidebarNavigationAccordionItem();
 
+  expect(screen.getByRole('button', { name: 'Accordion Item' })).toHaveAttribute(
+    'aria-expanded',
+    'false',
+  );
   checkAccordionAccessibility(false);
 });
 
@@ -72,15 +76,27 @@ it('should render the accordion open when defaultOpen is true', () => {
 it.each([true, false])('should respect the controlled open state %s', (isOpen) => {
   setupSidebarNavigationAccordionItem({ isOpen });
 
+  expect(screen.getByRole('button', { name: 'Accordion Item' })).toHaveAttribute(
+    'aria-expanded',
+    isOpen.toString(),
+  );
   checkAccordionAccessibility(isOpen);
 });
 
 it('should reflect controlled prop updates after mount', async () => {
   const { user } = setupControlledSidebarNavigationAccordionItem();
 
+  expect(screen.getByRole('button', { name: 'Accordion Item' })).toHaveAttribute(
+    'aria-expanded',
+    'false',
+  );
   checkAccordionAccessibility(false);
 
   await user.click(screen.getByRole('button', { name: 'Open accordion externally' }));
+  expect(screen.getByRole('button', { name: 'Accordion Item' })).toHaveAttribute(
+    'aria-expanded',
+    'true',
+  );
   checkAccordionAccessibility(true);
 
   await user.click(screen.getByRole('button', { name: 'Close accordion externally' }));

--- a/src/components/layout/sidebar-navigation/__tests__/SidebarNavigationAccordionItem-test.tsx
+++ b/src/components/layout/sidebar-navigation/__tests__/SidebarNavigationAccordionItem-test.tsx
@@ -20,6 +20,7 @@
 
 import { matchers } from '@emotion/jest';
 import { screen } from '@testing-library/react';
+import { useState } from 'react';
 import { renderWithMemoryRouter } from '~common/helpers/test-utils';
 import { IconBranch, IconExpand, IconGitBranch } from '../../../icons';
 import { SidebarNavigationAccordionChildItem } from '../SidebarNavigationAccordionChildItem';
@@ -54,11 +55,46 @@ it('should expand hidden elements when clicked', async () => {
   expect(onClose).toHaveBeenCalled();
 });
 
+it('should render uncontrolled and closed by default', () => {
+  setupSidebarNavigationAccordionItem();
+
+  checkAccordionAccessibility(false);
+});
+
 it('should render the accordion open when defaultOpen is true', () => {
   setupSidebarNavigationAccordionItem({ isDefaultOpen: true });
 
   checkAccordionPanelVisibility(true);
   expect(screen.getAllByRole('link')).toHaveLength(2);
+  checkAccordionAccessibility(true);
+});
+
+it.each([true, false])('should respect the controlled open state %s', (isOpen) => {
+  setupSidebarNavigationAccordionItem({ isOpen });
+
+  checkAccordionAccessibility(isOpen);
+});
+
+it('should reflect controlled prop updates after mount', async () => {
+  const { user } = setupControlledSidebarNavigationAccordionItem();
+
+  checkAccordionAccessibility(false);
+
+  await user.click(screen.getByRole('button', { name: 'Open accordion externally' }));
+  checkAccordionAccessibility(true);
+
+  await user.click(screen.getByRole('button', { name: 'Close accordion externally' }));
+  checkAccordionAccessibility(false);
+});
+
+it('should call onOpenChange without changing a controlled state', async () => {
+  const onOpenChange = jest.fn();
+  const { user } = setupSidebarNavigationAccordionItem({ isOpen: false, onOpenChange });
+
+  await user.click(screen.getByRole('button', { name: 'Accordion Item' }));
+
+  expect(onOpenChange).toHaveBeenCalledWith(true);
+  checkAccordionAccessibility(false);
 });
 
 it("shouldn't have any a11y violation", async () => {
@@ -171,6 +207,42 @@ describe('integration with SidebarNavigationAccordionChildItem', () => {
 function checkAccordionPanelVisibility(isOpen: boolean) {
   const region = screen.getByRole('region', { name: 'Accordion Item' });
   expect(region).toHaveAttribute('data-accordion-open', isOpen.toString());
+}
+
+function checkAccordionAccessibility(isOpen: boolean) {
+  const button = screen.getByRole('button', { name: 'Accordion Item' });
+  const region = screen.getByRole('region', { name: 'Accordion Item' });
+
+  expect(button).toHaveAttribute('aria-expanded', isOpen.toString());
+  expect(button).toHaveAttribute('aria-controls', region.id);
+  expect(region).toHaveAttribute('aria-labelledby', button.id);
+  checkAccordionPanelVisibility(isOpen);
+}
+
+function setupControlledSidebarNavigationAccordionItem() {
+  function ControlledExample() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <button onClick={() => setIsOpen(true)} type="button">
+          Open accordion externally
+        </button>
+        <button onClick={() => setIsOpen(false)} type="button">
+          Close accordion externally
+        </button>
+        <ul>
+          <SidebarNavigationAccordionItem Icon={IconExpand} isOpen={isOpen} label="Accordion Item">
+            <SidebarNavigationAccordionChildItem to="/sub-item-1">
+              Sub Item 1
+            </SidebarNavigationAccordionChildItem>
+          </SidebarNavigationAccordionItem>
+        </ul>
+      </>
+    );
+  }
+
+  return renderWithMemoryRouter(<ControlledExample />);
 }
 
 function setupSidebarNavigationAccordionItem(

--- a/src/components/layout/sidebar-navigation/index.ts
+++ b/src/components/layout/sidebar-navigation/index.ts
@@ -65,6 +65,18 @@ export const SidebarNavigation = Object.assign(SidebarNavigationRoot, {
    *   </SidebarNavigation.AccordionItem.Item>
    * </SidebarNavigation.AccordionItem>
    * ```
+   *
+   * Control the expanded state when it needs to follow application state:
+   * ```tsx
+   * <SidebarNavigation.AccordionItem
+   *   Icon={SecurityIcon}
+   *   isOpen={isSecurityOpen}
+   *   label="Security"
+   *   onOpenChange={setIsSecurityOpen}
+   * >
+   *   {items}
+   * </SidebarNavigation.AccordionItem>
+   * ```
    */
   AccordionItem: SidebarNavigationAccordionItemNamespace,
 

--- a/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
@@ -49,24 +49,6 @@ const accordionChildrenWithIcon = (
   </>
 );
 
-function AccordionStory({
-  isDefaultOpen = false,
-  isOpen,
-  ...props
-}: Readonly<SidebarNavigationAccordionItemProps>) {
-  if (typeof isOpen === 'boolean') {
-    return <Layout.SidebarNavigation.AccordionItem {...props} isOpen={isOpen} />;
-  }
-
-  return (
-    <Layout.SidebarNavigation.AccordionItem
-      {...props}
-      isDefaultOpen={isDefaultOpen}
-      key={`accordion-default-open-${isDefaultOpen.toString()}`}
-    />
-  );
-}
-
 function ControlledAccordionStory({
   isDefaultOpen: _isDefaultOpen,
   isOpen = false,
@@ -108,7 +90,6 @@ const meta: Meta<typeof Layout.SidebarNavigation.AccordionItem> = {
     ),
     basicWrapperDecorator,
   ],
-  render: (args) => <AccordionStory {...args} />,
 };
 
 export default meta;

--- a/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
@@ -49,6 +49,24 @@ const accordionChildrenWithIcon = (
   </>
 );
 
+function AccordionStory({
+  isDefaultOpen = false,
+  isOpen,
+  ...props
+}: Readonly<SidebarNavigationAccordionItemProps>) {
+  if (typeof isOpen === 'boolean') {
+    return <Layout.SidebarNavigation.AccordionItem {...props} isOpen={isOpen} />;
+  }
+
+  return (
+    <Layout.SidebarNavigation.AccordionItem
+      {...props}
+      isDefaultOpen={isDefaultOpen}
+      key={`accordion-default-open-${isDefaultOpen.toString()}`}
+    />
+  );
+}
+
 function ControlledAccordionStory({
   isDefaultOpen: _isDefaultOpen,
   isOpen = false,
@@ -90,6 +108,7 @@ const meta: Meta<typeof Layout.SidebarNavigation.AccordionItem> = {
     ),
     basicWrapperDecorator,
   ],
+  render: (args) => <AccordionStory {...args} />,
 };
 
 export default meta;

--- a/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
@@ -21,7 +21,8 @@
 /* eslint-disable no-console */
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Badge, IconBranch, Layout } from '../../../src';
+import { useArgs } from 'storybook/preview-api';
+import { Badge, IconBranch, Layout, type SidebarNavigationAccordionItemProps } from '../../../src';
 import { basicWrapperDecorator } from '../../helpers/BasicWrapper';
 
 const baseAccordionChildren = (
@@ -48,11 +49,36 @@ const accordionChildrenWithIcon = (
   </>
 );
 
+function ControlledAccordionStory({
+  isDefaultOpen: _isDefaultOpen,
+  isOpen = false,
+  onOpenChange,
+  ...props
+}: Readonly<SidebarNavigationAccordionItemProps>) {
+  const [, updateArgs] = useArgs();
+
+  function handleOpenChange(nextIsOpen: boolean) {
+    updateArgs({ isOpen: nextIsOpen });
+    onOpenChange?.(nextIsOpen);
+  }
+
+  return (
+    <Layout.SidebarNavigation.AccordionItem
+      {...props}
+      isOpen={isOpen}
+      onOpenChange={handleOpenChange}
+    />
+  );
+}
+
 const meta: Meta<typeof Layout.SidebarNavigation.AccordionItem> = {
   title: 'Echoes Patterns/Layout/SidebarNavigation/AccordionItem',
   component: Layout.SidebarNavigation.AccordionItem,
   argTypes: {
     isDefaultOpen: {
+      control: { type: 'boolean' },
+    },
+    isOpen: {
       control: { type: 'boolean' },
     },
   },
@@ -64,13 +90,6 @@ const meta: Meta<typeof Layout.SidebarNavigation.AccordionItem> = {
     ),
     basicWrapperDecorator,
   ],
-  render: ({ isDefaultOpen = false, ...args }) => (
-    <Layout.SidebarNavigation.AccordionItem
-      isDefaultOpen={isDefaultOpen}
-      key={`accordion-default-open-${isDefaultOpen.toString()}`}
-      {...args}
-    />
-  ),
 };
 
 export default meta;
@@ -116,6 +135,16 @@ export const withIcon: Story = {
     isDefaultOpen: true,
     label: 'Accordion',
   },
+};
+
+export const controlled: Story = {
+  args: {
+    Icon: IconBranch,
+    children: baseAccordionChildren,
+    isOpen: false,
+    label: 'Controlled accordion',
+  },
+  render: (args) => <ControlledAccordionStory {...args} />,
 };
 
 const fourNavItems = Array.from({ length: 4 }, (_, i) => (

--- a/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
+++ b/stories/layout/sidebar-navigation/SidebarNavigationAccordionItem-stories.tsx
@@ -163,7 +163,7 @@ export const controlled: Story = {
     isOpen: false,
     label: 'Controlled accordion',
   },
-  render: (args) => <ControlledAccordionStory {...args} />,
+  render: ControlledAccordionStory,
 };
 
 const fourNavItems = Array.from({ length: 4 }, (_, i) => (


### PR DESCRIPTION
## Summary
- Add controlled `isOpen` and `onOpenChange` support to sidebar accordion items.
- Preserve uncontrolled behavior with `isDefaultOpen`.
- Add controlled-state documentation, Storybook coverage, and interaction tests.

## Testing
- Added unit tests for controlled and uncontrolled state behavior, accessibility attributes, and callbacks.
- Not run (not requested).